### PR TITLE
Fix hidden unit computation

### DIFF
--- a/LSTM.lua
+++ b/LSTM.lua
@@ -71,6 +71,7 @@ function LSTM:buildHidden()
    hidden:add(concat)
    hidden:add(para)
    hidden:add(nn.CAddTable())
+   hidden:add(nn.Tanh())
    self.hiddenLayer = hidden
    return hidden
 end


### PR DESCRIPTION
If `LSTM:buildHidden()` is an implementation of equation 3 in the [readme](https://github.com/Element-Research/rnn#lstm), it was missing a Tanh nonlinearity at the end. This also corresponds to the "Vanilla LSTM" in [LSTM: A Search Space Odyssey](http://arxiv.org/pdf/1503.04069v1.pdf).