### PR TITLE
Fixing "double bias" in LSTM modules

### DIFF
--- a/FastLSTM.lua
+++ b/FastLSTM.lua
@@ -81,9 +81,8 @@ function LSTM:buildGate()
    -- Note : gate expects an input table : {input, output(t-1), cell(t-1)}
    local gate = nn.Sequential()
    local input2gate = nn.Linear(self.inputSize, self.outputSize)
-   local output2gate = nn.Linear(self.outputSize, self.outputSize)
+   local output2gate = nn.LinearNoBias(self.outputSize, self.outputSize)
    local cell2gate = nn.CMul(self.outputSize) -- diagonal cell to gate weight matrix
-   --output2gate:noBias() --TODO
    local para = nn.ParallelTable()
    para:add(input2gate):add(output2gate):add(cell2gate)
    gate:add(para)
@@ -105,9 +104,8 @@ end
 function LSTM:buildHidden()
    local hidden = nn.Sequential()
    local input2hidden = nn.Linear(self.inputSize, self.outputSize)
-   local output2hidden = nn.Linear(self.outputSize, self.outputSize) 
+   local output2hidden = nn.LinearNoBias(self.outputSize, self.outputSize)
    local para = nn.ParallelTable()
-   --output2hidden:noBias()
    para:add(input2hidden):add(output2hidden)
    -- input is {input, output(t-1), cell(t-1)}, but we only need {input, output(t-1)}
    local concat = nn.ConcatTable()

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -37,9 +37,8 @@ function LSTM:buildGate()
    -- Note : gate expects an input table : {input, output(t-1), cell(t-1)}
    local gate = nn.Sequential()
    local input2gate = nn.Linear(self.inputSize, self.outputSize)
-   local output2gate = nn.Linear(self.outputSize, self.outputSize)
+   local output2gate = nn.LinearNoBias(self.outputSize, self.outputSize)
    local cell2gate = nn.CMul(self.outputSize) -- diagonal cell to gate weight matrix
-   --output2gate:noBias() --TODO
    local para = nn.ParallelTable()
    para:add(input2gate):add(output2gate):add(cell2gate)
    gate:add(para)
@@ -61,9 +60,8 @@ end
 function LSTM:buildHidden()
    local hidden = nn.Sequential()
    local input2hidden = nn.Linear(self.inputSize, self.outputSize)
-   local output2hidden = nn.Linear(self.outputSize, self.outputSize) 
+   local output2hidden = nn.LinearNoBias(self.outputSize, self.outputSize)
    local para = nn.ParallelTable()
-   --output2hidden:noBias()
    para:add(input2hidden):add(output2hidden)
    -- input is {input, output(t-1), cell(t-1)}, but we only need {input, output(t-1)}
    local concat = nn.ConcatTable()

--- a/LinearNoBias.lua
+++ b/LinearNoBias.lua
@@ -1,0 +1,20 @@
+------------------------------------------------------------------------
+--[[ LinearNoBias ]]--
+-- Subclass of nn.Linear with no bias term
+-- The implementation is maximally independent of the implementation of nn.Linear
+-- (only assumption is that the bias and its gradient is stored in self.bias and self.gradBias)
+-- but is slightly inefficient (the bias term is still stored in memory and its
+-- gradient computed at every step).
+------------------------------------------------------------------------
+local LinearNoBias, Linear = torch.class('nn.LinearNoBias', 'nn.Linear')
+
+function LinearNoBias:__init(inputSize, outputSize)
+    Linear.__init(self, inputSize, outputSize)
+    self.bias:zero()
+end
+
+function LinearNoBias:accGradParameters(input, gradOutput, scale)
+    Linear.accGradParameters(self, input, gradOutput, scale)
+    self.gradBias:zero()
+end
+

--- a/init.lua
+++ b/init.lua
@@ -13,6 +13,7 @@ torch.include('rnn', 'test.lua')
 
 -- support modules
 torch.include('rnn', 'ZeroGrad.lua')
+torch.include('rnn', 'LinearNoBias.lua')
 
 -- recurrent modules
 torch.include('rnn', 'AbstractRecurrent.lua')


### PR DESCRIPTION
Probably not a permanent solution - something like `LinearNoBias` should be in a general-purpose package like `nnx` - but I'm using it for now, and figured you might want to as well