### PR TITLE
Require moses

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -1,3 +1,5 @@
+local _ = require 'moses'
+
 local AbstractRecurrent, parent
 if nn.AbstractRecurrent then -- prevent name conflicts with nnx
    AbstractRecurrent, parent = nn.AbstractRecurrent, nn.Container


### PR DESCRIPTION
Load in Moses as underscore '_'.
This is needed for example in line 135: "self.outputs = _.compact(self.outputs)".

Moses is a dependency of dpnn, which is a dependency of this rnn package.
Should Moses be a direct dependency of this package?