### PR TITLE
Fix LinearNoBias for repeated calls

### DIFF
--- a/LinearNoBias.lua
+++ b/LinearNoBias.lua
@@ -36,7 +36,7 @@ end
 function LinearNoBias:updateOutput(input)
    if input:dim() == 1 then
       self.output:resize(self.weight:size(1))
-      self.output:addmv(1, self.weight, input)
+      self.output:mv(self.weight, input)
    elseif input:dim() == 2 then
       local nframe = input:size(1)
       local nElement = self.output:nElement()


### PR DESCRIPTION
When copy-pasting from `Linear` I forgot to change this line, which meant that the output was actually accumulating over multiple calls to `updateOutput`. This should fix it (numerical gradient of LSTM are now correct).