### PR TITLE
Allow multiple outputs AbstractRecurrent

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -47,8 +47,8 @@ function AbstractRecurrent:updateGradInput(input, gradOutput)
    if self.copyGradOutputs then
       self.gradOutputs[self.step-1] = nn.rnn.recursiveCopy(self.gradOutputs[self.step-1] , gradOutput)
    else
-      self.gradOutputs[self.step-1] = self.gradOutputs[self.step-1] or gradOutput.new()
-      self.gradOutputs[self.step-1]:set(gradOutput)
+      self.gradOutputs[self.step-1] = self.gradOutputs[self.step-1] or nn.rnn.recursiveNew(gradOutput)
+      nn.rnn.recursiveSet(self.gradOutputs[self.step-1], gradOutput)
    end
 end
 

--- a/recursiveUtils.lua
+++ b/recursiveUtils.lua
@@ -138,3 +138,18 @@ function rnn.recursiveSum(t2)
    end
    return sum
 end
+
+function rnn.recursiveNew(t2)
+   if torch.type(t2) == 'table' then
+      local t1 = {}
+      for key,_ in pairs(t2) do
+         t1[key] = rnn.recursiveNew(t2[key])
+      end
+      return t1
+   elseif torch.isTensor(t2) then
+      return t2.new()
+   else
+      error("expecting tensor or table thereof. Got "
+           ..torch.type(t2).." instead")
+   end
+end


### PR DESCRIPTION
I ran into an error when using the `Sequencer` on a `Recurrent` module with multiple outputs, because it tried to call `.new()` on a table. This fixes that error.