### PR TITLE
nn.Recursor(module, rho) - work in progress 

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -19,6 +19,7 @@ function AbstractRecurrent:__init(rho)
    self.scales = {}
    
    self.gradParametersAccumulated = false
+   self.onlineBackward = false
    self.step = 1
    
    -- stores internal states of Modules at different time-steps
@@ -31,43 +32,67 @@ function AbstractRecurrent:getStepModule(step)
    assert(step, "expecting step at arg 1")
    local recurrentModule = self.sharedClones[step]
    if not recurrentModule then
-      recurrentModule = self.recurrentModule:sharedClone()
+      recurrentModule = self.recurrentModule:stepClone()
       self.sharedClones[step] = recurrentModule
    end
    return recurrentModule
 end
 
-function AbstractRecurrent:updateGradInput(input, gradOutput)
-   -- Back-Propagate Through Time (BPTT) happens in updateParameters()
-   -- for now we just keep a list of the gradOutputs
-   if self.copyGradOutputs then
-      self.gradOutputs[self.step-1] = nn.rnn.recursiveCopy(self.gradOutputs[self.step-1] , gradOutput)
+function AbstractRecurrent:updateGradInput(input, gradOutput)      
+   if self.onlineBackward then
+      -- updateGradInput will be called in reverse order of time
+      -- BPTT for one time-step (rho = 1)
+      self.backStep = self.backStep or self.step
+      if self.copyGradOutputs then
+         self.gradOutputs[self.backStep-1] = nn.rnn.recursiveCopy(self.gradOutputs[self.backStep-1] , gradOutput)
+      else
+         self.gradOutputs[self.backStep-1] = self.gradOutputs[self.backStep-1] or nn.rnn.recursiveNew(gradOutput)
+         nn.rnn.recursiveSet(self.gradOutputs[self.backStep-1], gradOutput)
+      end
+      self.gradInput = self:updateGradInputThroughTime(self.backStep, 1)
+      self.backStep = self.backStep - 1
+      assert(self.gradInput)
+      return self.gradInput
    else
-      self.gradOutputs[self.step-1] = self.gradOutputs[self.step-1] or nn.rnn.recursiveNew(gradOutput)
-      nn.rnn.recursiveSet(self.gradOutputs[self.step-1], gradOutput)
+      -- Back-Propagate Through Time (BPTT) happens in updateParameters()
+      -- for now we just keep a list of the gradOutputs
+      if self.copyGradOutputs then
+         self.gradOutputs[self.step-1] = nn.rnn.recursiveCopy(self.gradOutputs[self.step-1] , gradOutput)
+      else
+         self.gradOutputs[self.step-1] = self.gradOutputs[self.step-1] or nn.rnn.recursiveNew(gradOutput)
+         nn.rnn.recursiveSet(self.gradOutputs[self.step-1], gradOutput)
+      end
    end
 end
 
 function AbstractRecurrent:accGradParameters(input, gradOutput, scale)
-   -- Back-Propagate Through Time (BPTT) happens in updateParameters()
-   -- for now we just keep a list of the scales
-   self.scales[self.step-1] = scale or 1
+   if self.onlineBackward then
+      -- accGradParameters will be called in reverse order of time
+      -- BPTT for one time-step (rho = 1)
+      assert(self.backStep < self.step, "Missing updateGradInput")
+      self.scales[self.backStep] = scale or 1
+      self:accGradParametersThroughTime(self.backStep+1, 1)
+   else
+      -- Back-Propagate Through Time (BPTT) happens in updateParameters()
+      -- for now we just keep a list of the scales
+      self.scales[self.step-1] = scale or 1
+   end
 end
 
-function AbstractRecurrent:backwardThroughTime()
+function AbstractRecurrent:backwardThroughTime(step, rho)
    return self.gradInput
 end
 
-function AbstractRecurrent:updateGradInputThroughTime()
+function AbstractRecurrent:updateGradInputThroughTime(step, rho)
 end
 
-function AbstractRecurrent:accGradParametersThroughTime()
+function AbstractRecurrent:accGradParametersThroughTime(step, rho)
 end
 
-function AbstractRecurrent:accUpdateGradParametersThroughTime(lr)
+function AbstractRecurrent:accUpdateGradParametersThroughTime(lr, step, rho)
 end
 
-function AbstractRecurrent:backwardUpdateThroughTime(learningRate)
+function AbstractRecurrent:backwardUpdateThroughTime(learningRate, step, rho)
    local gradInput = self:updateGradInputThroughTime()
    self:accUpdateGradParametersThroughTime(learningRate)
    return gradInput
@@ -182,6 +207,18 @@ function AbstractRecurrent:reinforce(reward)
    return self:includingSharedClones(function()
       return parent.reinforce(self, reward)
    end)
+end
+
+function AbstractRecurrent:sharedClone(shareParams, shareGradParams, clones, pointers, stepClone)
+   if stepClone then 
+      return self 
+   else
+      return parent.sharedClone(self, shareParams, shareGradParams, clones, pointers, stepClone)
+   end
+end
+
+function AbstractRecurrent:backwardOnline(online)
+   self.onlineBackward = (online == nil) and true or online
 end
 
 -- backwards compatibility

--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -94,7 +94,7 @@ end
 function AbstractRecurrent:accUpdateGradParametersThroughTime(lr, step, rho)
 end
 
-function AbstractRecurrent:backwardUpdateThroughTime(learningRate, step, rho)
+function AbstractRecurrent:backwardUpdateThroughTime(learningRate)
    local gradInput = self:updateGradInputThroughTime()
    self:accUpdateGradParametersThroughTime(learningRate)
    return gradInput

--- a/AbstractSequencer.lua
+++ b/AbstractSequencer.lua
@@ -1,6 +1,7 @@
 local AbstractSequencer, parent = torch.class("nn.AbstractSequencer", "nn.Container")
 
 function AbstractSequencer:getStepModule(step)
+   -- DEPRECATED 27 Oct 2015. Wrap your internal modules into a Recursor instead.
    assert(self.sharedClones, "no sharedClones for type "..torch.type(self))
    assert(step, "expecting step at arg 1")
    local module = self.sharedClones[step]

--- a/AbstractSequencer.lua
+++ b/AbstractSequencer.lua
@@ -24,6 +24,10 @@ function AbstractSequencer:backwardOnline(online)
    return
 end
 
+-- AbstractSequence handles its own rho internally (dynamically)
+function AbstractSequencer:maxBPTTstep(rho)
+end
+
 AbstractSequencer.includingSharedClones = nn.AbstractRecurrent.includingSharedClones
 AbstractSequencer.type = nn.AbstractRecurrent.type
 AbstractSequencer.training = nn.AbstractRecurrent.training

--- a/AbstractSequencer.lua
+++ b/AbstractSequencer.lua
@@ -15,6 +15,15 @@ end
 function AbstractSequencer:backwardThroughTime()
 end
 
+function AbstractSequencer:sharedClone(shareParams, shareGradParams, clones, pointers, stepClone)
+   -- stepClone is ignored (always false, i.e. uses sharedClone)
+   return parent.sharedClone(self, shareParams, shareGradParams, clones, pointers)
+end
+
+function AbstractSequencer:backwardOnline(online)
+   return
+end
+
 AbstractSequencer.includingSharedClones = nn.AbstractRecurrent.includingSharedClones
 AbstractSequencer.type = nn.AbstractRecurrent.type
 AbstractSequencer.training = nn.AbstractRecurrent.training

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -178,26 +178,29 @@ function LSTM:updateOutput(input)
    self.cell = cell
    
    self.step = self.step + 1
+   self.gradPrevOutput = nil
+   self.backStep = nil
    self.gradParametersAccumulated = false
    -- note that we don't return the cell, just the output
    return self.output
 end
 
-function LSTM:backwardThroughTime()
+function LSTM:backwardThroughTime(timeStep, rho)
    assert(self.step > 1, "expecting at least one updateOutput")
    self.gradInputs = {} -- used by Sequencer, Repeater
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   
    if self.fastBackward then
-      local gradPrevOutput
-      for step=self.step-1,math.max(stop,1),-1 do
+      for step=timeStep-1,math.max(stop,1),-1 do
          -- set the output/gradOutput states of current Module
          local recurrentModule = self:getStepModule(step)
          
          -- backward propagate through this step
          local gradOutput = self.gradOutputs[step]
-         if gradPrevOutput then
-            self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], gradPrevOutput)
+         if self.gradPrevOutput then
+            self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], self.gradPrevOutput)
             nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
             gradOutput = self._gradOutputs[step]
          end
@@ -208,13 +211,12 @@ function LSTM:backwardThroughTime()
          local inputTable = {self.inputs[step], output, cell}
          local gradCell = (step == self.step-1) and (self.userNextGradCell or self.zeroTensor) or self.gradCells[step]
          local gradInputTable = recurrentModule:backward(inputTable, {gradOutput, gradCell}, scale)
-         gradInput, gradPrevOutput, gradCell = unpack(gradInputTable)
-         if step > math.max(stop,1) then
-            self.gradCells[step-1] = gradCell
-         end
+         gradInput, self.gradPrevOutput, gradCell = unpack(gradInputTable)
+         self.gradCells[step-1] = gradCell
          table.insert(self.gradInputs, 1, gradInput)
-         if self.userPrevOutput then self.userGradPrevOutput = gradPrevOutput end
+         if self.userPrevOutput then self.userGradPrevOutput = self.gradPrevOutput end
       end
+      self.gradParametersAccumulated = true
       return gradInput
    else
       local gradInput = self:updateGradInputThroughTime()
@@ -223,20 +225,22 @@ function LSTM:backwardThroughTime()
    end
 end
 
-function LSTM:updateGradInputThroughTime()
+function LSTM:updateGradInputThroughTime(timeStep, rho)
    assert(self.step > 1, "expecting at least one updateOutput")
    self.gradInputs = {}
-   local gradInput, gradPrevOutput
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,1),-1 do
+   local gradInput
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+
+   for step=timeStep-1,math.max(stop,1),-1 do
       -- set the output/gradOutput states of current Module
       local recurrentModule = self:getStepModule(step)
       
       -- backward propagate through this step
       local gradOutput = self.gradOutputs[step]
-      if gradPrevOutput then
-         self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], gradPrevOutput)
+      if self.gradPrevOutput then
+         self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], self.gradPrevOutput)
          nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
          gradOutput = self._gradOutputs[step]
       end
@@ -246,21 +250,21 @@ function LSTM:updateGradInputThroughTime()
       local inputTable = {self.inputs[step], output, cell}
       local gradCell = (step == self.step-1) and (self.userNextGradCell or self.zeroTensor) or self.gradCells[step]
       local gradInputTable = recurrentModule:updateGradInput(inputTable, {gradOutput, gradCell})
-      gradInput, gradPrevOutput, gradCell = unpack(gradInputTable)
-      if step > math.max(stop,1) then
-         self.gradCells[step-1] = gradCell
-      end
+      gradInput, self.gradPrevOutput, gradCell = unpack(gradInputTable)
+      self.gradCells[step-1] = gradCell
       table.insert(self.gradInputs, 1, gradInput)
-      if self.userPrevOutput then self.userGradPrevOutput = gradPrevOutput end
+      if self.userPrevOutput then self.userGradPrevOutput = self.gradPrevOutput end
    end
    
    return gradInput
 end
 
-function LSTM:accGradParametersThroughTime()
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,1),-1 do
+function LSTM:accGradParametersThroughTime(timeStep, rho)
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   
+   for step=timeStep-1,math.max(stop,1),-1 do
       -- set the output/gradOutput states of current Module
       local recurrentModule = self:getStepModule(step)
       
@@ -279,10 +283,12 @@ function LSTM:accGradParametersThroughTime()
    return gradInput
 end
 
-function LSTM:accUpdateGradParametersThroughTime(lr)
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,1),-1 do
+function LSTM:accUpdateGradParametersThroughTime(lr, timeStep, rho)
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   
+   for step=timeStep-1,math.max(stop,1),-1 do
       -- set the output/gradOutput states of current Module
       local recurrentModule = self:getStepModule(step)
       

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -179,7 +179,8 @@ function LSTM:updateOutput(input)
    
    self.step = self.step + 1
    self.gradPrevOutput = nil
-   self.backStep = nil
+   self.updateGradInputStep = nil
+   self.accGradParametersStep = nil
    self.gradParametersAccumulated = false
    -- note that we don't return the cell, just the output
    return self.output

--- a/Module.lua
+++ b/Module.lua
@@ -42,3 +42,12 @@ function Module:backwardOnline(online)
       end
    end
 end
+
+-- set the maximum number of backpropagation through time (BPTT) time-steps
+function Module:maxBPTTstep(rho)
+   if self.modules then
+      for i, module in ipairs(self.modules) do
+         module:maxBPTTstep(rho)
+      end
+   end
+end

--- a/Module.lua
+++ b/Module.lua
@@ -28,3 +28,17 @@ function Module:backwardThroughTime()
       end
    end
 end
+
+function Module:stepClone(shareParams, shareGradParams, clones, pointers)
+   return self:sharedClone(shareParams, shareGradParams, clones, pointers, true)
+end
+
+-- notifies all AbstractRecurrent instances not wrapped by an AbstractSequencer
+-- that the backward calls will be handled online (in reverse order of forward time).
+function Module:backwardOnline(online)
+   if self.modules then
+      for i, module in ipairs(self.modules) do
+         module:backwardOnline(online)
+      end
+   end
+end

--- a/README.md
+++ b/README.md
@@ -4,15 +4,23 @@ This is a Recurrent Neural Network library that extends Torch's nn.
 You can use it to build RNNs, LSTMs, BRNNs, BLSTMs, and so forth and so on.
 This library includes documentation for the following objects:
 
+Modules that consider successive calls to `forward` different time-steps in a sequence :
  * [AbstractRecurrent](#rnn.AbstractRecurrent) : an abstract class inherited by Recurrent and LSTM;
  * [Recurrent](#rnn.Recurrent) : a generalized recurrent neural network container;
  * [LSTM](#rnn.LSTM) : a vanilla Long-Short Term Memory module;
   * [FastLSTM](#rnn.FastLSTM) : a faster [LSTM](#rnn.LSTM);
+ * [Recursor](#rnn.Recursor) : decorates a module to make it conform to the [AbstractRecurrent](#rnn.AbstractRecurrent) interface;
+
+Modules that decorate `AbstractRecurrent` instances and recurse through 
+entire sequences during a single call to `forward` :
+ * [AbstractSequencer](#rnn.AbstractSequencer) : an abstract class inherited by Sequencer, Repeater, RecurrentAttention, etc.;
  * [Sequencer](#rnn.Sequencer) : applies an encapsulated module to all elements in an input sequence;
  * [BiSequencer](#rnn.BiSequencer) : used for implementing Bidirectional RNNs and LSTMs;
  * [BiSequencerLM](#rnn.BiSequencerLM) : used for implementing Bidirectional RNNs and LSTMs for language models;
  * [Repeater](#rnn.Repeater) : repeatedly applies the same input to an AbstractRecurrent instance;
  * [RecurrentAttention](#rnn.RecurrentAttention) : a generalized attention model for [REINFORCE modules](https://github.com/nicholas-leonard/dpnn#nn.Reinforce);
+ 
+Criterions used for handling sequential inputs and targets :
  * [SequencerCriterion](#rnn.SequencerCriterion) : sequentially applies the same criterion to a sequence of inputs and targets;
  * [RepeaterCriterion](#rnn.RepeaterCriterion) : repeatedly applies the same criterion with the same target on a sequence;
 
@@ -63,18 +71,36 @@ Again, the actual BPTT happens in the `updateParameters`,
 `backwardThroughTime` or `backwardUpdateThroughTime` methods.
 So this method just keeps a copy of the `scales` for later.
 
-### backwardThroughTime() ###
+<a name='rnn.AbstractRecurrent.backwardThroughTime'></a>
+### backwardThroughTime([step, rho]) ###
 This method calls `updateGradInputThroughTime` followed by `accGradParametersThroughTime`.
-This is where the actual BPTT happens.
+This is where the actual BPTT happens. 
 
-### updateGradInputThroughTime() ###
+Argument `step` specifies that the BPTT should only happen 
+starting from time-step `step` (which defaults to `self.step`, i.e. the current time-step).
+Argument `rho` specifies for how many time-steps the BPTT should happen 
+(which defaults to `self.rho`). 
+For example, supposing we called `updageOutput` 5 times (so `self.step=6`), 
+if we want to backpropagate through step 5 only, we can call :
+
+```lua
+rnn:backwardThroughTime(6, 1)
+```
+
+### updateGradInputThroughTime([step, rho]) ###
 Iteratively calls `updateGradInput` for all time-steps in reverse order 
 (from the end to the start of the sequence). Returns the `gradInput` of 
 the first time-step.
 
-### accGradParametersThroughTime() ###
+See [backwardThroughTime](#rnn.AbstractRecurrent.backwardThroughTime) for an 
+explanation of optional arguments `step` and `rho`.
+
+### accGradParametersThroughTime([step, rho]) ###
 Iteratively calls `accGradParameters` for all time-steps in reverse order 
 (from the end to the start of the sequence). 
+
+See [backwardThroughTime](#rnn.AbstractRecurrent.backwardThroughTime) for an 
+explanation of optional arguments `step` and `rho`.
 
 ### accUpdateGradParametersThroughTime(learningRate) ###
 Iteratively calls `accUpdateGradParameters` for all time-steps in reverse order 
@@ -107,6 +133,85 @@ Otherwise, the previous state will be used to activate the next, which
 will often lead to instability. This is caused by the previous state being
 the result of now changed parameters. It is also good practice to call 
 `forget` at the start of each new sequence.
+
+<a name='rnn.AbstractRecurrent.maxBPTTstep'></a>
+###  maxBPTTstep(rho) ###
+This method sets the maximum number of time-steps for which to perform 
+backpropagation through time (BPTT). So say you set this to `rho = 3` time-steps,
+feed-forward for 4 steps, and then backpropgate, only the last 3 steps will be 
+used for the backpropagation. If your AbstractRecurrent instance is wrapped 
+by a [Sequencer](#rnn.Sequencer), this will be handled auto-magically by the Sequencer.
+Otherwise, setting this value to a large value (i.e. 9999999), is good for most, if not all, cases.
+
+<a name='rnn.AbstractRecurrent.backwardOnline'></a>
+### backwardOnline([online]) ###
+Call this method with `online=true` (the default) to make calls to 
+`backward` (including `updateGradInput` and `accGradParameters`) 
+perform backpropagation through time. This requires that calls to 
+these `backward` methods be performed in the opposite order of the 
+`forward` calls.
+
+So for example, given the following data and `rnn` :
+```lua
+-- backpropagate every 5 time steps
+rho = 5
+
+-- generate some dummy inputs and gradOutputs sequences
+inputs, gradOutputs = {}, {}
+for step=1,rho do
+   inputs[step] = torch.randn(3,10)
+   gradOutputs[step] = torch.randn(3,10)
+end
+
+-- an AbstractRecurrent instance
+rnn = nn.LSTM(10,10)
+```
+
+We could feed-forward and backpropagate through time like this :
+
+```lua
+for step=1,rho do
+   rnn:forward(inputs[step])
+   rnn:backward(inputs[step], gradOutputs[step])
+end
+rnn:backwardThroughTime()
+rnn:udpateParameters(0.1)
+rnn:forget()
+```
+
+In the above example, each call to `backward` only saves the sequence of 
+`gradOutput` Tensors. It is the call to `backwardThroughTime()` that 
+actually does the backpropagation through time.
+
+Alternatively, we could backpropagate through time *online*.
+To do so, we need to activate this feature by calling the `backwardOnline` method
+(once, at the start of training). Then we will make calls to `backward` in 
+reverse order of the calls to `forward`. Each such call will backpropagate 
+through a time-step, begining at the last time-step, ending at the first.
+So the above example can be implemented like this instead :
+
+```lua
+rnn:backwardOnline()
+-- forward
+for step=1,rho do
+   rnn:forward(inputs[step])
+end
+
+-- backward (in reverse order of forward calls)
+gradInputs = {}
+for step=rho,1,-1 do
+   gradInputs[step] = rnn:backward(inputs[step], gradOutputs[step])
+end
+
+rnn:udpateParameters(0.1)
+rnn:forget()
+```
+
+Also notice that `backwardOnline` makes the calls to `backward` generate 
+a `gradInput` for every time-step. Whereas without this, these 
+would only be made available via the `rnn.gradInputs` table after the 
+call to `backwardThroughTime()`.
+
 
 ### training() ###
 In training mode, the network remembers all previous `rho` (number of time-steps)
@@ -212,13 +317,63 @@ while true do
    if i % updateInterval == 0 then
       -- backpropagates through time (BPTT) :
       -- 1. backward through feedback and input layers,
-      -- 2. updates parameters
       rnn:backwardThroughTime()
+      -- 2. updates parameters
       rnn:updateParameters(lr)
       rnn:zeroGradParameters()
+      -- 3. reset the internal time-step counter
+      rnn:forget()
    end
 end
 ```
+
+Another option, is to perform the backpropagation through time using 
+the normal Module interface. The only requirement is that you 
+wrap your rnn into a [Recursor](#rnn.Recursor) and
+call `backwardOnline()` and then call `backward` 
+in reverse order of the `forward` calls:
+
+```lua
+rnn = nn.Recursor(rnn, rho)
+rnn:backwardOnline()
+
+i=1
+inputs, outputs, targets = {}, {}
+while true do
+   -- a batch of inputs
+   local input = sequence:index(1, offsets)
+   local output = rnn:forward(input)
+   -- incement indices
+   offsets:add(1)
+   for j=1,batchSize do
+      if offsets[j] > nIndex then
+         offsets[j] = 1
+      end
+   end
+   local target = sequence:index(1, offsets)
+   local err = criterion:forward(output, target)
+   
+   -- save these for the BPTT
+   table.insert(inputs, input)
+   table.insert(outputs, output)
+   table.insert(targets, target)
+   
+   i = i + 1
+   -- note that updateInterval < rho
+   if i % updateInterval == 0 then
+      for step=updateInterval,1,-1 do
+         local gradOutput = criterion:backward(outputs[step], targets[step])
+         rnn:backward(inputs[step], gradOutput)
+      end
+      rnn:updateParameters(lr)
+      rnn:zeroGradParameters()
+      
+      inputs, outputs, targets = {}, {}, {}
+   end
+end
+```
+
+This is basically what a `Sequencer` does internally.
 
 <a name='rnn.Recurrent.Sequencer'></a>
 ### Decorate it with a Sequencer ###
@@ -228,6 +383,10 @@ such that an entire sequence (a table) can be presented with a single `forward/b
 This is actually the recommended approach as it allows RNNs to be stacked and makes the 
 rnn conform to the Module interface, i.e. a `forward`, `backward` and `updateParameters` are all 
 that is required ( `Sequencer` handles the `backwardThroughTime` internally ).
+
+```lua
+seq = nn.Sequencer(module)
+```
 
 The following example is similar to the previous one, except that 
  
@@ -242,17 +401,17 @@ batchSize = 8
 rho = 5
 hiddenSize = 10
 nIndex = 10000
--- RNN
-r = nn.Recurrent(
-   hiddenSize, nn.LookupTable(nIndex, hiddenSize), 
-   nn.Linear(hiddenSize, hiddenSize), nn.Sigmoid(), 
-   rho
-)
 
-rnn = nn.Sequential()
-rnn:add(nn.Sequencer(r))
-rnn:add(nn.Sequencer(nn.Linear(hiddenSize, nIndex)))
-rnn:add(nn.Sequencer(nn.LogSoftMax()))
+mlp = nn.Sequential()
+   :add(nn.Recurrent(
+      hiddenSize, nn.LookupTable(nIndex, hiddenSize), 
+      nn.Linear(hiddenSize, hiddenSize), nn.Sigmoid(), 
+      rho
+   )
+   :add(nn.Linear(hiddenSize, nIndex))
+   :add(nn.LogSoftMax())
+
+rnn = nn.Sequencer(mlp)
 
 criterion = nn.SequencerCriterion(nn.ClassNLLCriterion())
 
@@ -361,6 +520,12 @@ Note that we recommend decorating the `LSTM` with a `Sequencer`
 
 A faster version of the [LSTM](#rnn.LSTM). 
 Basically, the input, forget and output gates, as well as the hidden state are computed at one fell swoop.
+
+<a name='rnn.AbstractSequencer'></a>
+## AbstractSequencer ##
+This abastract class implements a light interface shared by 
+subclasses like : `Sequencer`, `Repeater`, `RecurrentAttention`, `BiSequencer` and so on.
+
   
 <a name='rnn.Sequencer'></a>
 ## Sequencer ##
@@ -373,10 +538,10 @@ seq = nn.Sequencer(module)
 ```
 
 This Module is a kind of [decorator](http://en.wikipedia.org/wiki/Decorator_pattern) 
-used to abstract away the intricacies of AbstractRecurrent `modules`. While the latter 
-require a sequence to be presented one input at a time, each with its own call to `forward` (and `backward`),
-the Sequencer forwards an input sequence (a table) into an output sequence (a table of the same length).
-It also takes care of calling `forget`, `backwardThroughTime` and other such AbstractRecurrent-specific methods.
+used to abstract away the intricacies of `AbstractRecurrent` modules. While an `AbstractRecurrent` instance 
+requires that a sequence to be presented one input at a time, each with its own call to `forward` (and `backward`),
+the `Sequencer` forwards an `input` sequence (a table) into an `output` sequence (a table of the same length).
+It also takes care of calling `forget`, `backwardOnline` and other such AbstractRecurrent-specific methods.
 
 For example, `rnn` : an instance of nn.AbstractRecurrent, can forward an `input` sequence one forward at a time:
 ```lua
@@ -397,9 +562,17 @@ The `Sequencer` can also take non-recurrent Modules (i.e. non-AbstractRecurrent 
 input to produce an output table of the same length. 
 This is especially useful for processing variable length sequences (tables).
 
-Note that for now, it is only possible to decorate either recurrent or non-recurrent Modules. 
-Specifically, it cannot handle non-recurrent Modules containing recurrent Modules. 
-Instead, either Modules should be encapsulated by its own `Sequencer`. This may change in the future.
+Internally, the `Sequencer` expects the decorated `module` to be an 
+`AbstractRecurrent` instance. When this is not the case, the `module` 
+is automatically decorated with a [Recursor](#rnn.Recursor) module, which makes it 
+conform to the `AbstractRecurrent` interface. 
+
+Note : this is due a recent update (27 Oct 2015), as before this 
+`AbstractRecurrent` and and non-`AbstractRecurrent` instances needed to 
+be decorated by their own `Sequencer`. The recent update, which introduced the 
+`Recursor` decorator, allows a single `Sequencer` to wrap any type of module, 
+`AbstractRecurrent`, non-`AbstractRecurrent` or a composite structure of both types.
+Nevertheless, existing code shouldn't be affected by the change.
 
 ### remember([mode]) ###
 When `mode='both'` (the default), the Sequencer will not call [forget](#nn.AbstractRecurrent.forget) at the start of 
@@ -414,6 +587,91 @@ Accepted values for argument `mode` are as follows :
 
 ### forget() ###
 Calls the decorated AbstractRecurrent module's `forget` method.
+
+<a name='rnn.Recursor'></a>
+## Recursor ##
+
+This module recorates a `module` to be used within an `AbstractSequencer` instance.
+It does this by making the decorated module conform to the `AbstractRecurrent` interface,
+which like the `LSTM` and `Recurrent` classes, this class inherits. 
+
+```lua
+rec = nn.Recursor(module[, rho])
+```
+
+For each successive call to `updateOutput` (i.e. `forward`), this 
+decorator will create a `stepClone()` of the decorated `module`. 
+So for each time-step, it clones the `module`. Both the clone and 
+original share parameters and gradients w.r.t. parameters. However, for 
+modules that already conform to the `AbstractRecurrent` interface, 
+the clone and original module are one in the same (i.e. no clone).
+
+Examples :
+
+Let's assume I want to stack two LSTMs. I could use two sequencers :
+
+```lua
+lstm = nn.Sequential()
+   :add(nn.Sequencer(nn.LSTM(100,100)))
+   :add(nn.Sequencer(nn.LSTM(100,100)))
+```
+
+Using a `Recursor`, I make the same model with a single `Sequencer` :
+
+```lua
+lstm = nn.Sequencer(
+   nn.Recursor(
+      nn.Sequential()
+         :add(nn.LSTM(100,100))
+         :add(nn.LSTM(100,100))
+      )
+   )
+```
+
+Actually, the `Sequencer` will wrap any non-`AbstractRecurrent` module automatically, 
+so I could simplify this further to :
+
+```lua
+lstm = nn.Sequencer(
+   nn.Sequential()
+      :add(nn.LSTM(100,100))
+      :add(nn.LSTM(100,100))
+   )
+```
+
+I can also add a `Linear` between the two `LSTM`s. In this case,
+a `Linear` will be cloned (and have its parameters shared) for each time-step,
+while the `LSTM`s will do whatever cloning internally :
+
+```lua
+lstm = nn.Sequencer(
+   nn.Sequential()
+      :add(nn.LSTM(100,100))
+      :add(nn.Linear(100,100))
+      :add(nn.LSTM(100,100))
+   )
+```
+
+`AbstractRecurrent` instances like `Recursor`, `Recurrent` and `LSTM` are 
+expcted to manage time-steps internally. Non-`AbstractRecurrent` instances
+can be wrapped by a `Recursor` to have the same behavior. 
+
+Every call to `forward` on an `AbstractRecurrent` instance like `Recursor` 
+will increment the `self.step` attribute by 1, using a shared parameter clone
+for each successive time-step (for a maximum of `rho` time-steps, which defaults to 9999999).
+In this way, with the help of [backwardOnline](#rnn.AbstractRecurrent.backwardOnline) 
+we can then call `backward` in reverse order of the `forward` calls 
+to perform backpropagation through time (BPTT). Which is exactly what 
+[AbstractSequencer](#rnn.AbstractSequencer) instances do internally.
+The `backward` call, which is actually divided into calls to `updateGradInput` and 
+`accGradParameters`, decrements by 1 the `self.udpateGradInputStep` and `self.accGradParametersStep`
+respectively, starting at `self.step`.
+Successive calls to `backward` will decrement these counters and use them to 
+backpropagate through the appropriate internall step-wise shared-parameter clones.
+
+Anyway, in most cases, you will not have to deal with the `Recursor` object directly as
+`AbstractSequencer` instances automatically decorate non-`AbstractRecurrent` instances
+with a `Recursor` in their constructors.
 
 <a name='rnn.BiSequencer'></a>
 ## BiSequencer ##

--- a/Recurrent.lua
+++ b/Recurrent.lua
@@ -89,33 +89,36 @@ function Recurrent:updateOutput(input)
    self.outputs[self.step] = output
    self.output = output
    self.step = self.step + 1
+   self.gradPrevOutput = nil
+   self.backStep = nil
    self.gradParametersAccumulated = false
    return self.output
 end
 
 -- not to be confused with the hit movie Back to the Future
-function Recurrent:backwardThroughTime()
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
+function Recurrent:backwardThroughTime(timeStep, timeRho)
+   timeStep = timeStep or self.step
+   local rho = math.min(timeRho or self.rho, timeStep-1)
+   local stop = timeStep - rho
    local gradInput
    if self.fastBackward then
       self.gradInputs = {}
-      local gradPrevOutput
-      for step=self.step-1,math.max(stop, 2),-1 do
+      for step=timeStep-1,math.max(stop, 2),-1 do
          local recurrentModule = self:getStepModule(step)
          
          -- backward propagate through this step
          local input = self.inputs[step]
          local output = self.outputs[step-1]
          local gradOutput = self.gradOutputs[step] 
-         if gradPrevOutput then
-            self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], gradPrevOutput)
+         if self.gradPrevOutput then
+            self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], self.gradPrevOutput)
             nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
             gradOutput = self._gradOutputs[step]
          end
          local scale = self.scales[step]
          
-         gradInput, gradPrevOutput = unpack(recurrentModule:backward({input, output}, gradOutput, scale))
+         gradInput, self.gradPrevOutput = unpack(recurrentModule:backward({input, output}, gradOutput, scale))
+         
          table.insert(self.gradInputs, 1, gradInput)
       end
       
@@ -123,8 +126,8 @@ function Recurrent:backwardThroughTime()
          -- backward propagate through first step
          local input = self.inputs[1]
          local gradOutput = self.gradOutputs[1]
-         if gradPrevOutput then
-            self._gradOutputs[1] = nn.rnn.recursiveCopy(self._gradOutputs[1], gradPrevOutput)
+         if self.gradPrevOutput then
+            self._gradOutputs[1] = nn.rnn.recursiveCopy(self._gradOutputs[1], self.gradPrevOutput)
             nn.rnn.recursiveAdd(self._gradOutputs[1], gradOutput)
             gradOutput = self._gradOutputs[1]
          end
@@ -134,32 +137,33 @@ function Recurrent:backwardThroughTime()
       end
       self.gradParametersAccumulated = true
    else
-      gradInput = self:updateGradInputThroughTime()
-      self:accGradParametersThroughTime()
+      gradInput = self:updateGradInputThroughTime(timeStep, timeRho)
+      self:accGradParametersThroughTime(timeStep, timeRho)
    end
    return gradInput
 end
 
-function Recurrent:updateGradInputThroughTime()
+function Recurrent:updateGradInputThroughTime(timeStep, rho)
    assert(self.step > 1, "expecting at least one updateOutput")
+   timeStep = timeStep or self.step
    self.gradInputs = {}
-   local gradInput, gradPrevOutput
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,2),-1 do
+   local gradInput
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   for step=timeStep-1,math.max(stop,2),-1 do
       local recurrentModule = self:getStepModule(step)
       
       -- backward propagate through this step
       local input = self.inputs[step]
       local output = self.outputs[step-1]
       local gradOutput = self.gradOutputs[step]
-      if gradPrevOutput then
-         self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], gradPrevOutput)
+      if self.gradPrevOutput then
+         self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], self.gradPrevOutput)
          nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
          gradOutput = self._gradOutputs[step]
       end
       
-      gradInput, gradPrevOutput = unpack(recurrentModule:updateGradInput({input, output}, gradOutput))
+      gradInput, self.gradPrevOutput = unpack(recurrentModule:updateGradInput({input, output}, gradOutput))
       table.insert(self.gradInputs, 1, gradInput)
    end
    
@@ -167,8 +171,8 @@ function Recurrent:updateGradInputThroughTime()
       -- backward propagate through first step
       local input = self.inputs[1]
       local gradOutput = self.gradOutputs[1]
-      if gradPrevOutput then
-         self._gradOutputs[1] = nn.rnn.recursiveCopy(self._gradOutputs[1], gradPrevOutput)
+      if self.gradPrevOutput then
+         self._gradOutputs[1] = nn.rnn.recursiveCopy(self._gradOutputs[1], self.gradPrevOutput)
          nn.rnn.recursiveAdd(self._gradOutputs[1], gradOutput)
          gradOutput = self._gradOutputs[1]
       end
@@ -179,16 +183,17 @@ function Recurrent:updateGradInputThroughTime()
    return gradInput
 end
 
-function Recurrent:accGradParametersThroughTime()
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,2),-1 do
+function Recurrent:accGradParametersThroughTime(timeStep, rho)
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   for step=timeStep-1,math.max(stop,2),-1 do
       local recurrentModule = self:getStepModule(step)
       
       -- backward propagate through this step
       local input = self.inputs[step]
       local output = self.outputs[step-1]
-      local gradOutput = (step == self.step-1) and self.gradOutputs[step] or self._gradOutputs[step]
+      local gradOutput = (step == timeStep-1) and self.gradOutputs[step] or self._gradOutputs[step]
 
       local scale = self.scales[step]
       recurrentModule:accGradParameters({input, output}, gradOutput, scale)
@@ -197,7 +202,7 @@ function Recurrent:accGradParametersThroughTime()
    if stop <= 1 then
       -- backward propagate through first step
       local input = self.inputs[1]
-      local gradOutput = (1 == self.step-1) and self.gradOutputs[1] or self._gradOutputs[1]
+      local gradOutput = (1 == timeStep-1) and self.gradOutputs[1] or self._gradOutputs[1]
       local scale = self.scales[1]
       self.initialModule:accGradParameters(input, gradOutput, scale)
    end
@@ -225,7 +230,8 @@ function Recurrent:accUpdateGradParametersThroughInitialModule(lr, rho)
    transferModule:accUpdateGradParameters(startModule.output, gradOutput, lr*scale)
 end
 
-function Recurrent:accUpdateGradParametersThroughTime(lr)
+function Recurrent:accUpdateGradParametersThroughTime(lr, timeStep, rho)
+   assert(not (timeStep or rho), "Not Implemented")
    local rho = math.min(self.rho, self.step-1)
    local stop = self.step - rho
    for step=self.step-1,math.max(stop,2),-1 do

--- a/Recurrent.lua
+++ b/Recurrent.lua
@@ -193,7 +193,7 @@ function Recurrent:accGradParametersThroughTime(timeStep, rho)
       -- backward propagate through this step
       local input = self.inputs[step]
       local output = self.outputs[step-1]
-      local gradOutput = (step == timeStep-1) and self.gradOutputs[step] or self._gradOutputs[step]
+      local gradOutput = (step == self.step-1) and self.gradOutputs[step] or self._gradOutputs[step]
 
       local scale = self.scales[step]
       recurrentModule:accGradParameters({input, output}, gradOutput, scale)
@@ -202,7 +202,7 @@ function Recurrent:accGradParametersThroughTime(timeStep, rho)
    if stop <= 1 then
       -- backward propagate through first step
       local input = self.inputs[1]
-      local gradOutput = (1 == timeStep-1) and self.gradOutputs[1] or self._gradOutputs[1]
+      local gradOutput = (1 == self.step-1) and self.gradOutputs[1] or self._gradOutputs[1]
       local scale = self.scales[1]
       self.initialModule:accGradParameters(input, gradOutput, scale)
    end
@@ -231,10 +231,10 @@ function Recurrent:accUpdateGradParametersThroughInitialModule(lr, rho)
 end
 
 function Recurrent:accUpdateGradParametersThroughTime(lr, timeStep, rho)
-   assert(not (timeStep or rho), "Not Implemented")
-   local rho = math.min(self.rho, self.step-1)
-   local stop = self.step - rho
-   for step=self.step-1,math.max(stop,2),-1 do
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   for step=timeStep-1,math.max(stop,2),-1 do
       local recurrentModule = self:getStepModule(step)
       
       -- backward propagate through this step

--- a/Recurrent.lua
+++ b/Recurrent.lua
@@ -90,7 +90,8 @@ function Recurrent:updateOutput(input)
    self.output = output
    self.step = self.step + 1
    self.gradPrevOutput = nil
-   self.backStep = nil
+   self.updateGradInputStep = nil
+   self.accGradParametersStep = nil
    self.gradParametersAccumulated = false
    return self.output
 end
@@ -162,7 +163,7 @@ function Recurrent:updateGradInputThroughTime(timeStep, rho)
          nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
          gradOutput = self._gradOutputs[step]
       end
-      
+
       gradInput, self.gradPrevOutput = unpack(recurrentModule:updateGradInput({input, output}, gradOutput))
       table.insert(self.gradInputs, 1, gradInput)
    end

--- a/RecurrentAttention.lua
+++ b/RecurrentAttention.lua
@@ -20,6 +20,12 @@ function RecurrentAttention:__init(rnn, action, nStep, hiddenSize)
    self.rnn = (not torch.isTypeOf(rnn, 'nn.AbstractRecurrent')) and nn.Recursor(rnn) or rnn
    -- backprop through time (BPTT) will be done online (in reverse order of forward)
    self.rnn:backwardOnline()
+   for i,modula in ipairs(self.rnn:listModules()) do
+      if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
+         modula.copyInputs = false
+         modula.copyGradOutputs = false
+      end
+   end
    
    -- samples an x,y actions for each example
    self.action =  (not torch.isTypeOf(action, 'nn.AbstractRecurrent')) and nn.Recursor(action) or action 

--- a/RecurrentAttention.lua
+++ b/RecurrentAttention.lua
@@ -10,20 +10,24 @@ local RecurrentAttention, parent = torch.class("nn.RecurrentAttention", "nn.Abst
 
 function RecurrentAttention:__init(rnn, action, nStep, hiddenSize)
    parent.__init(self)
-   assert(torch.isTypeOf(rnn, 'nn.AbstractRecurrent'))
    assert(torch.isTypeOf(action, 'nn.Module'))
    assert(torch.type(nStep) == 'number')
    assert(torch.type(hiddenSize) == 'table')
    assert(torch.type(hiddenSize[1]) == 'number', "Does not support table hidden layers" )
    
    self.rnn = rnn
-   self.rnn.copyInputs = true
-   self.action = action -- samples an x,y actions for each example
+   -- we can decorate the module with a Recursor to make it AbstractRecurrent
+   self.rnn = (not torch.isTypeOf(rnn, 'nn.AbstractRecurrent')) and nn.Recursor(rnn) or rnn
+   -- backprop through time (BPTT) will be done online (in reverse order of forward)
+   self.rnn:backwardOnline()
+   
+   -- samples an x,y actions for each example
+   self.action =  (not torch.isTypeOf(action, 'nn.AbstractRecurrent')) and nn.Recursor(action) or action 
+   self.action:backwardOnline()
    self.hiddenSize = hiddenSize
    self.nStep = nStep
    
    self.modules = {self.rnn, self.action}
-   self.sharedClones = {self.action:sharedClone()} -- action clones
    
    self.output = {} -- rnn output
    self.actions = {} -- action output
@@ -35,20 +39,19 @@ end
 
 function RecurrentAttention:updateOutput(input)
    self.rnn:forget()
+   self.action:forget()
    local nDim = input:dim()
    
    for step=1,self.nStep do
-      -- we maintain a copy of action (with shared params) for each time-step
-      local action = self:getStepModule(step)
       
       if step == 1 then
          -- sample an initial starting actions by forwarding zeros through the action
          self._initInput = self._initInput or input.new()
          self._initInput:resize(input:size(1),table.unpack(self.hiddenSize)):zero()
-         self.actions[1] = action:updateOutput(self._initInput)
+         self.actions[1] = self.action:updateOutput(self._initInput)
       else
          -- sample actions from previous hidden activation (rnn output)
-         self.actions[step] = action:updateOutput(self.output[step-1])
+         self.actions[step] = self.action:updateOutput(self.output[step-1])
       end
       
       -- rnn handles the recurrence internally
@@ -64,13 +67,19 @@ function RecurrentAttention:updateGradInput(input, gradOutput)
    assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
    assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
     
-   -- backward through the action
+   -- back-propagate through time (BPTT)
    for step=self.nStep,1,-1 do
-      local action = self:getStepModule(step)
-      
-      local gradOutput_ = gradOutput[step]
+      -- 1. backward through the action layer
+      local gradOutput_, gradAction_ = gradOutput[step]
       if self.forwardActions then
          gradOutput_, gradAction_ = unpack(gradOutput[step])
+      else
+         -- Note : gradOutput is ignored by REINFORCE modules so we give a zero Tensor instead
+         self._gradAction = self._gradAction or self.action.output.new()
+         if not self._gradAction:isSameSizeAs(self.action.output) then
+            self._gradAction:resizeAs(self.action.output):zero()
+         end
+         gradAction_ = self._gradAction
       end
       
       if step == self.nStep then
@@ -82,24 +91,14 @@ function RecurrentAttention:updateGradInput(input, gradOutput)
       
       if step == 1 then
          -- backward through initial starting actions
-         action:updateGradInput(self._initInput, gradAction_ or action.output)
+         self.action:updateGradInput(self._initInput, gradAction_)
       else
-         -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
-         local gradAction = action:updateGradInput(self.output[step-1], gradAction_ or action.output)
+         local gradAction = self.action:updateGradInput(self.output[step-1], gradAction_)
          self.gradHidden[step-1] = nn.rnn.recursiveCopy(self.gradHidden[step-1], gradAction)
       end
-   end
-   
-   -- backward through the rnn layer
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
-      self.rnn:updateGradInput(input, self.gradHidden[step])
-   end
-   -- back-propagate through time (BPTT)
-   self.rnn:updateGradInputThroughTime()
-   
-   for step=self.nStep,1,-1 do
-      local gradInput = self.rnn.gradInputs[step][1]
+      
+      -- 2. backward through the rnn layer
+      local gradInput = self.rnn:updateGradInput(input, self.gradHidden[step])[1]
       if step == self.nStep then
          self.gradInput:resizeAs(gradInput):copy(gradInput)
       else
@@ -114,28 +113,22 @@ function RecurrentAttention:accGradParameters(input, gradOutput, scale)
    assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
    assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
    assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
-    
-   -- backward through the action layers
+   
+   -- back-propagate through time (BPTT)
    for step=self.nStep,1,-1 do
-      local action = self:getStepModule(step)
-      local gradAction_ = self.forwardActions and gradOutput[step][2] or nil
+      -- 1. backward through the action layer
+      local gradAction_ = self.forwardActions and gradOutput[step][2] or self._gradAction
             
       if step == 1 then
          -- backward through initial starting actions
-         action:accGradParameters(self._initInput, gradAction_ or action.output, scale)
+         self.action:accGradParameters(self._initInput, gradAction_, scale)
       else
-         -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
-         action:accGradParameters(self.output[step-1], gradAction_ or action.output, scale)
+         self.action:accGradParameters(self.output[step-1], gradAction_, scale)
       end
-   end
-   
-   -- backward through the rnn layer
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
+      
+      -- 2. backward through the rnn layer
       self.rnn:accGradParameters(input, self.gradHidden[step], scale)
    end
-   -- back-propagate through time (BPTT)
-   self.rnn:accGradParametersThroughTime()
 end
 
 function RecurrentAttention:accUpdateGradParameters(input, gradOutput, lr)
@@ -145,25 +138,20 @@ function RecurrentAttention:accUpdateGradParameters(input, gradOutput, lr)
     
    -- backward through the action layers
    for step=self.nStep,1,-1 do
-      local action = self:getStepModule(step)
-      local gradAction_ = self.forwardActions and gradOutput[step][2] or nil
+      -- 1. backward through the action layer
+      local gradAction_ = self.forwardActions and gradOutput[step][2] or self._gradAction
       
       if step == 1 then
          -- backward through initial starting actions
-         action:accUpdateGradParameters(self._initInput, gradAction_ or action.output, lr)
+         self.action:accUpdateGradParameters(self._initInput, gradAction_, lr)
       else
          -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
-         action:accUpdateGradParameters(self.output[step-1], gradAction_ or action.output, lr)
+         self.action:accUpdateGradParameters(self.output[step-1], gradAction_, lr)
       end
-   end
-   
-   -- backward through the rnn layer
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
+      
+      -- 2. backward through the rnn layer
       self.rnn:accUpdateGradParameters(input, self.gradHidden[step], lr)
    end
-   -- back-propagate through time (BPTT)
-   self.rnn:accUpdateGradParametersThroughTime()
 end
 
 function RecurrentAttention:type(type)

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -127,6 +127,7 @@ end
 
 function Recursor:backwardOnline(online)
    assert(oneline ~= false, "Recursor only supports online backwards")
+   parent.backwardOnline(self)
 end
 
 function Recursor:forget(offset)

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -1,0 +1,129 @@
+------------------------------------------------------------------------
+--[[ Recursor ]]--
+-- Decorates module to be used within an AbstractSequencer.
+-- It does this by making the decorated module conform to the 
+-- AbstractRecurrent interface (which is inherited by LSTM/Recurrent) 
+------------------------------------------------------------------------
+local Recursor, parent = torch.class('nn.Recursor', 'nn.AbstractRecurrent')
+
+function Recursor:__init(module, rho)
+   parent.__init(self, rho or 9999999)
+
+   self.recurrentModule = module
+   self.recurrentModule:backwardOnline()
+   self.onlineBackward = true
+   
+   self.modules = {module}
+end
+
+function Recursor:updateOutput(input)
+   if self.train ~= false then
+      -- set/save the output states
+      self:recycle()
+      local recurrentModule = self:getStepModule(self.step)
+      output = recurrentModule:updateOutput(input)
+   else
+      output = self.recurrentModule:updateOutput(input)
+   end
+   
+   if self.train ~= false then
+      local input_ = self.inputs[self.step]
+      self.inputs[self.step] = self.copyInputs 
+         and nn.rnn.recursiveCopy(input_, input) 
+         or nn.rnn.recursiveSet(input_, input)     
+   end
+   
+   self.outputs[self.step] = output
+   self.output = output
+   self.step = self.step + 1
+   self.gradParametersAccumulated = false
+   return self.output
+end
+
+function Recursor:backwardThroughTime(timeStep, timeRho)
+   timeStep = timeStep or self.step
+   local rho = math.min(timeRho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   local gradInput
+   if self.fastBackward then
+      self.gradInputs = {}
+      for step=timeStep-1,math.max(stop, 1),-1 do
+         -- backward propagate through this step
+         local recurrentModule = self:getStepModule(step)
+         gradInput = recurrentModule:backward(self.inputs[step], self.gradOutputs[step] , self.scales[step])
+         table.insert(self.gradInputs, 1, gradInput)
+      end
+      
+      self.gradParametersAccumulated = true
+   else
+      gradInput = self:updateGradInputThroughTime(timeStep, timeRho)
+      self:accGradParametersThroughTime(timeStep, timeRho)
+   end
+   return gradInput
+end
+
+function Recursor:updateGradInputThroughTime(timeStep, rho)
+   assert(self.step > 1, "expecting at least one updateOutput")
+   self.gradInputs = {}
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   local gradInput
+   for step=timeStep-1,math.max(stop,1),-1 do
+      -- backward propagate through this step
+      local recurrentModule = self:getStepModule(step)
+      gradInput = recurrentModule:updateGradInput(self.inputs[step], self.gradOutputs[step])
+      table.insert(self.gradInputs, 1, gradInput)
+   end
+   
+   return gradInput
+end
+
+function Recursor:accGradParametersThroughTime(timeStep, rho)
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   for step=timeStep-1,math.max(stop,1),-1 do
+      -- backward propagate through this step
+      local recurrentModule = self:getStepModule(step)
+      recurrentModule:accGradParameters(self.inputs[step], self.gradOutputs[step], self.scales[step])
+   end
+   
+   self.gradParametersAccumulated = true
+   return gradInput
+end
+
+function Recursor:accUpdateGradParametersThroughTime(lr, timeStep, rho)
+   timeStep = timeStep or self.step
+   local rho = math.min(rho or self.rho, timeStep-1)
+   local stop = timeStep - rho
+   for step=timeStep-1,math.max(stop,1),-1 do
+      -- backward propagate through this step
+      local recurrentModule = self:getStepModule(step)
+      recurrentModule:accUpdateGradParameters(self.inputs[step], self.gradOutputs[step], lr*self.scales[step])
+   end
+   
+   return gradInput
+end
+
+function Recursor:includingSharedClones(f)
+   local modules = self.modules
+   self.modules = {}
+   local sharedClones = self.sharedClones
+   self.sharedClones = nil
+   for i,modules in ipairs{modules, sharedClones} do
+      for j, module in pairs(modules) do
+         table.insert(self.modules, module)
+      end
+   end
+   local r = f()
+   self.modules = modules
+   self.sharedClones = sharedClones
+   return r
+end
+
+function Recursor:backwardOnline(online)
+   assert(oneline ~= false, "Recursor only supports online backwards")
+end
+
+Recursor.__tostring__ = nn.Decorator.__tostring__

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -13,6 +13,7 @@ function Recursor:__init(module, rho)
    self.recurrentModule:backwardOnline()
    self.onlineBackward = true
    
+   self.module = module
    self.modules = {module}
 end
 
@@ -36,6 +37,8 @@ function Recursor:updateOutput(input)
    self.outputs[self.step] = output
    self.output = output
    self.step = self.step + 1
+   self.updateGradInputStep = nil
+   self.accGradParametersStep = nil
    self.gradParametersAccumulated = false
    return self.output
 end
@@ -124,6 +127,17 @@ end
 
 function Recursor:backwardOnline(online)
    assert(oneline ~= false, "Recursor only supports online backwards")
+end
+
+function Recursor:forget(offset)
+   parent.forget(self, offset)
+   nn.Module.forget(self)
+   return self
+end
+
+function Recursor:maxBPTTstep(rho)
+   self.rho = rho
+   nn.Module.maxBPTTstep(self, rho)
 end
 
 Recursor.__tostring__ = nn.Decorator.__tostring__

--- a/Repeater.lua
+++ b/Repeater.lua
@@ -1,75 +1,78 @@
 ------------------------------------------------------------------------
 --[[ Repeater ]]--
 -- Encapsulates an AbstractRecurrent instance (rnn) which is repeatedly 
--- presented with the same input for nStep time steps.
--- The output is a table of nStep outputs of the rnn.
+-- presented with the same input for rho time steps.
+-- The output is a table of rho outputs of the rnn.
 ------------------------------------------------------------------------
 assert(not nn.Repeater, "update nnx package : luarocks install nnx")
 local Repeater, parent = torch.class('nn.Repeater', 'nn.AbstractSequencer')
 
-function Repeater:__init(rnn, nStep)
+function Repeater:__init(module, rho)
    parent.__init(self)
-   assert(torch.type(nStep) == 'number', "expecting number value for arg 2")
-   self.nStep = nStep
-   self.rnn = rnn
-   assert(torch.isTypeOf(rnn, "nn.AbstractRecurrent"), "expecting AbstractRecurrent instance for arg 1")
-   self.modules[1] = rnn
+   assert(torch.type(rho) == 'number', "expecting number value for arg 2")
+   self.rho = rho
+   self.module = (not torch.isTypeOf(rnn, 'nn.AbstractRecurrent')) and nn.Recursor(module) or module
+   
+   self.module:backwardOnline()
+   self.module:maxBPTTstep(rho) -- hijack rho (max number of time-steps for backprop)
+   
+   self.modules[1] = self.module
    self.output = {}
 end
 
 function Repeater:updateOutput(input)
-   self.rnn:forget()
+   self.module:forget()
    -- TODO make copy outputs optional
-   for step=1,self.nStep do
-      self.output[step] = nn.rnn.recursiveCopy(self.output[step], self.rnn:updateOutput(input))
+   for step=1,self.rho do
+      self.output[step] = nn.rnn.recursiveCopy(self.output[step], self.module:updateOutput(input))
    end
    return self.output
 end
 
 function Repeater:updateGradInput(input, gradOutput)
-   assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+   assert(self.module.step - 1 == self.rho, "inconsistent rnn steps")
    assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
-   assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
-      self.rnn:updateGradInput(input, gradOutput[step])
-   end
-   -- back-propagate through time (BPTT)
-   self.rnn:updateGradInputThroughTime()
+   assert(#gradOutput == self.rho, "gradOutput should have rho elements")
    
-   for i,currentGradInput in ipairs(self.rnn.gradInputs) do
-      if i == 1 then
-         self.gradInput = nn.rnn.recursiveCopy(self.gradInput, currentGradInput)
+   -- back-propagate through time (BPTT)
+   for step=self.rho,1,-1 do
+      local gradInput = self.module:updateGradInput(input, gradOutput[step])
+      if step == self.rho then
+         self.gradInput = nn.rnn.recursiveCopy(self.gradInput, gradInput)
       else
-         nn.rnn.recursiveAdd(self.gradInput, currentGradInput)
+         nn.rnn.recursiveAdd(self.gradInput, gradInput)
       end
    end
-   
+
    return self.gradInput
 end
 
 function Repeater:accGradParameters(input, gradOutput, scale)
-   assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+   assert(self.module.step - 1 == self.rho, "inconsistent rnn steps")
    assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
-   assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
-      self.rnn:accGradParameters(input, gradOutput[step], scale)
-   end
+   assert(#gradOutput == self.rho, "gradOutput should have rho elements")
+   
    -- back-propagate through time (BPTT)
-   self.rnn:accGradParametersThroughTime()
+   for step=self.rho,1,-1 do
+      self.module:accGradParameters(input, gradOutput[step], scale)
+   end
+   
+end
+
+function Repeater:maxBPTTstep(rho)
+   self.rho = rho
+   self.module:maxBPTTstep(rho)
 end
 
 function Repeater:accUpdateGradParameters(input, gradOutput, lr)
-   assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+   assert(self.module.step - 1 == self.rho, "inconsistent rnn steps")
    assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
-   assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
-   for step=1,self.nStep do
-      self.rnn.step = step + 1
-      self.rnn:accGradParameters(input, gradOutput[step], 1)
-   end
+   assert(#gradOutput == self.rho, "gradOutput should have rho elements")
+   
    -- back-propagate through time (BPTT)
-   self.rnn:accUpdateGradParametersThroughTime(lr)
+   for step=self.rho,1,-1 do
+      self.module:accUpdateGradParameters(input, gradOutput[step], lr)
+   end
 end
 
 function Repeater:__tostring__()
@@ -80,7 +83,7 @@ function Repeater:__tostring__()
    str = str .. tab .. '     V         V             V     '.. line
    str = str .. tab .. tostring(self.modules[1]):gsub(line, line .. tab) .. line
    str = str .. tab .. '     V         V             V     '.. line
-   str = str .. tab .. '[output(1),output(2),...,output('..self.nStep..')]' .. line
+   str = str .. tab .. '[output(1),output(2),...,output('..self.rho..')]' .. line
    str = str .. '}'
    return str
 end

--- a/Repeater.lua
+++ b/Repeater.lua
@@ -21,6 +21,8 @@ function Repeater:__init(module, rho)
 end
 
 function Repeater:updateOutput(input)
+   self.module = self.module or self.rnn -- backwards compatibility
+
    self.module:forget()
    -- TODO make copy outputs optional
    for step=1,self.rho do

--- a/Sequencer.lua
+++ b/Sequencer.lua
@@ -21,9 +21,9 @@ function Sequencer:__init(module)
    self.module = (not torch.isTypeOf(module, 'nn.AbstractRecurrent')) and nn.Recursor(module) or module
    -- backprop through time (BPTT) will be done online (in reverse order of forward)
    self.module:backwardOnline()
-   self.modules = {module}
+   self.modules = {self.module}
    
-   for i,modula in ipairs(module:listModules()) do
+   for i,modula in ipairs(self.module:listModules()) do
       if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
          modula.copyInputs = false
          modula.copyGradOutputs = false

--- a/Sequencer.lua
+++ b/Sequencer.lua
@@ -27,7 +27,6 @@ function Sequencer:__init(module)
       if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
          modula.copyInputs = false
          modula.copyGradOutputs = false
-         break
       end
    end
    

--- a/Sequencer.lua
+++ b/Sequencer.lua
@@ -16,33 +16,21 @@ function Sequencer:__init(module)
    if not torch.isTypeOf(module, 'nn.Module') then
       error"Sequencer: expecting nn.Module instance at arg 1"
    end
-   self.module = module
-   self.isRecurrent = torch.isTypeOf(module, "nn.AbstractRecurrent")
-   self.modules[1] = module
-   self.sharedClones = {}
-   if not self.isRecurrent then
-      self.sharedClones[1] = self.module
-      -- test that it doesn't contain a recurrent module :
-      local err = false
-      for i,modula in ipairs(module:listModules()) do
-         if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
-            err = modula
-            break
-         end
+   
+   -- we can decorate the module with a Recursor to make it AbstractRecurrent
+   self.module = (not torch.isTypeOf(module, 'nn.AbstractRecurrent')) and nn.Recursor(module) or module
+   -- backprop through time (BPTT) will be done online (in reverse order of forward)
+   self.module:backwardOnline()
+   self.modules = {module}
+   
+   for i,modula in ipairs(module:listModules()) do
+      if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
+         modula.copyInputs = false
+         modula.copyGradOutputs = false
+         break
       end
-      
-      if err then
-         error("Sequencer: non-recurrent Module should not contain a "..
-         "nested recurrent Modules. Recurrent module is "..torch.type(err)..
-         ". Use a Sequencer instance for each recurrent module. "..
-         "And encapsulate the rest of the non-recurrent modules into "..
-         "one or many Sequencers. Yes you can encapsulate many non-recurrent"..
-         " modules in a single Sequencer (as long as they don't include recurrent modules.") 
-      end
-   else
-      self.module.copyInputs = false
-      self.module.copyGradOutputs = false
    end
+   
    self.output = {}
    
    -- table of buffers used for evaluation
@@ -56,123 +44,72 @@ end
 
 function Sequencer:updateOutput(inputTable)
    assert(torch.type(inputTable) == 'table', "expecting input table")
-   if self.isRecurrent then
-      -- Note that the Sequencer hijacks the rho attribute of the rnn
-      self.module.rho = #inputTable
-      if self.train ~= false then -- training
-         if not (self._remember == 'train' or self._remember == 'both') then
-            self.module:forget()
-         end
-         self.output = {}
-         for step, input in ipairs(inputTable) do
-            self.output[step] = self.module:updateOutput(input)
-         end
-      else -- evaluation
-         if not (self._remember == 'eval' or self._remember == 'both') then
-            self.module:forget()
-         end
-         -- during evaluation, recurrent modules reuse memory (i.e. outputs)
-         -- so we need to copy each output into our own
-         for step, input in ipairs(inputTable) do
-            self.output[step] = nn.rnn.recursiveCopy(
-               self.output[step] or table.remove(self._output, 1), 
-               self.module:updateOutput(input)
-            )
-         end
-         -- remove extra output tensors (save for later)
-         for i=#inputTable+1,#self.output do
-            table.insert(self._output, self.output[i])
-            self.output[i] = nil
-         end
+
+   -- Note that the Sequencer hijacks the rho attribute of the rnn
+   self.module:maxBPTTstep(#inputTable)
+   if self.train ~= false then -- training
+      if not (self._remember == 'train' or self._remember == 'both') then
+         self.module:forget()
       end
-   else
       self.output = {}
       for step, input in ipairs(inputTable) do
-         -- set output states for this step
-         local module = self:getStepModule(step)
-         
-         -- forward propagate this step
-         self.output[step] = module:updateOutput(input)
+         self.output[step] = self.module:updateOutput(input)
+      end
+   else -- evaluation
+      if not (self._remember == 'eval' or self._remember == 'both') then
+         self.module:forget()
+      end
+      -- during evaluation, recurrent modules reuse memory (i.e. outputs)
+      -- so we need to copy each output into our own table
+      for step, input in ipairs(inputTable) do
+         self.output[step] = nn.rnn.recursiveCopy(
+            self.output[step] or table.remove(self._output, 1), 
+            self.module:updateOutput(input)
+         )
+      end
+      -- remove extra output tensors (save for later)
+      for i=#inputTable+1,#self.output do
+         table.insert(self._output, self.output[i])
+         self.output[i] = nil
       end
    end
+   
    return self.output
 end
 
 function Sequencer:updateGradInput(inputTable, gradOutputTable)
+   assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
+   assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
+   
+   -- back-propagate through time (BPTT)
    self.gradInput = {}
-   if self.isRecurrent then
-      assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
-      assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
-      local i = 1
-      for step=self.module.step-#inputTable+1,self.module.step do
-         self.module.step = step
-         self.module:updateGradInput(inputTable[i], gradOutputTable[i])
-         i = i + 1
-      end
-      -- back-propagate through time (BPTT)
-      self.module:updateGradInputThroughTime()
-      assert(self.module.gradInputs, "recurrent module did not fill gradInputs")
-      assert(#inputTable == #self.module.gradInputs, #inputTable.." ~= "..#self.module.gradInputs)
-      for i=1,#inputTable do
-         self.gradInput[i] = self.module.gradInputs[i]
-      end
-      assert(#self.gradInput == #inputTable, "missing gradInputs (rho is too low?)")
-   else
-      for step, input in ipairs(inputTable) do
-         -- set the output/gradOutput states for this step
-         local module = self:getStepModule(step)
-         
-         -- backward propagate this step
-         self.gradInput[step] = module:updateGradInput(input, gradOutputTable[step])
-      end
+   for step=#gradOutputTable,1,-1 do
+      self.gradInput[step] = self.module:updateGradInput(inputTable[step], gradOutputTable[step])
    end
+   
+   assert(#inputTable == #self.gradInput, #inputTable.." ~= "..#self.gradInput)
+
    return self.gradInput
 end
 
 function Sequencer:accGradParameters(inputTable, gradOutputTable, scale)
-   if self.isRecurrent then
-      assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
-      assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
-      local i = 1
-      for step=self.module.step-#inputTable+1,self.module.step do
-         self.module.step = step
-         self.module:accGradParameters(inputTable[i], gradOutputTable[i], scale)
-         i = i + 1
-      end
-      -- back-propagate through time (BPTT)
-      self.module:accGradParametersThroughTime()
-   else
-      for step, input in ipairs(inputTable) do
-         -- set the output/gradOutput states for this step
-         local module = self:getStepModule(step)
-         
-         -- accumulate parameters for this step
-         module:accGradParameters(input, gradOutputTable[step], scale)
-      end
-   end
+   assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
+   assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
+   
+   -- back-propagate through time (BPTT)
+   for step=#gradOutputTable,1,-1 do
+      self.module:accGradParameters(inputTable[step], gradOutputTable[step], scale)
+   end   
 end
 
 function Sequencer:accUpdateGradParameters(inputTable, gradOutputTable, lr)
-   if self.isRecurrent then
-      assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
-      assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
-      local i = 1
-      for step=self.module.step-#inputTable+1,self.module.step do
-         self.module.step = step
-         self.module:accGradUpdateParameters(inputTable[i], gradOutputTable[i], lr)
-         i = i + 1
-      end
-      -- back-propagate through time (BPTT)
-      self.module:accUpdateGradParametersThroughTime(lr)
-   else
-      for step, input in ipairs(inputTable) do
-         -- set the output/gradOutput states for this step
-         local module = self:getStepModule(step)
-         
-         -- accumulate parameters for this step
-         module:accUpdateGradParameters(input, gradOutputTable[step], lr)
-      end
-   end
+   assert(torch.type(gradOutputTable) == 'table', "expecting gradOutput table")
+   assert(#gradOutputTable == #inputTable, "gradOutput should have as many elements as input")
+   
+   -- back-propagate through time (BPTT)
+   for step=#gradOutputTable,1,-1 do
+      self.module:accUpdateGradParameters(inputTable[step], gradOutputTable[step], lr)
+   end     
 end
 
 -- Toggle to feed long sequences using multiple forwards.
@@ -189,7 +126,7 @@ function Sequencer:remember(remember)
 end
 
 function Sequencer:training()
-   if self.isRecurrent and self.train == false then
+   if self.train == false then
       -- empty output table (tensor mem was managed by seq)
       for i,output in ipairs(self.output) do
          table.insert(self._output, output)
@@ -202,7 +139,7 @@ function Sequencer:training()
 end
 
 function Sequencer:evaluate()
-   if self.isRecurrent and self.train ~= false then
+   if self.train ~= false then
       -- empty output table (tensor mem was managed by rnn)
       self.output = {}
       -- forget at the start of each evaluation

--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@ torch.include('rnn', 'AbstractRecurrent.lua')
 torch.include('rnn', 'Recurrent.lua')
 torch.include('rnn', 'LSTM.lua')
 torch.include('rnn', 'FastLSTM.lua')
+torch.include('rnn', 'Recursor.lua')
 
 torch.include('rnn', 'AbstractSequencer.lua')
 torch.include('rnn', 'Repeater.lua')

--- a/scripts/evaluate-rva.lua
+++ b/scripts/evaluate-rva.lua
@@ -56,7 +56,7 @@ sg = model:findModules('nn.SpatialGlimpse')[1]
 
 -- stochastic or deterministic
 for i=1,#ra.actions do
-   local rn = ra:getStepModule(i):findModules('nn.ReinforceNormal')[1]
+   local rn = ra.action:getStepModule(i):findModules('nn.ReinforceNormal')[1]
    rn.stochastic = opt.stochastic
 end
 
@@ -75,7 +75,7 @@ input = inputs:narrow(1,1,10)
 model:training() -- otherwise the rnn doesn't save intermediate time-step states
 if not opt.stochastic then
    for i=1,#ra.actions do
-      local rn = ra:getStepModule(i):findModules('nn.ReinforceNormal')[1]
+      local rn = ra.action:getStepModule(i):findModules('nn.ReinforceNormal')[1]
       rn.stdev = 0 -- deterministic
    end
 end

--- a/test/test.lua
+++ b/test/test.lua
@@ -1490,6 +1490,7 @@ function rnntest.RecurrentAttention()
       mytester:assertTensorEq(params[i], params2[i], 0.0000001, "RecurrentAttention(Recursor), param err "..i)
       mytester:assertTensorEq(gradParams[i], gradParams2[i], 0.0000001, "RecurrentAttention(Recursor), gradParam err "..i)
    end
+   
 end
    
 function rnntest.LSTM_nn_vs_nngraph()
@@ -2015,7 +2016,13 @@ function rnntest.Recursor()
    -- USE CASE 3. Sequencer(Recursor)
    
    local re2 = nn.LSTM(inputSize, outputSize)
-   local seq = nn.Sequencer(nn.Recursor(re2:clone()))
+   local lstm2 = re2:clone()
+   local rec = nn.Recursor(lstm2)
+   local seq = nn.Sequencer(rec)
+   mytester:assert(not rec.copyInputs)
+   mytester:assert(not rec.copyGradOutputs)
+   mytester:assert(not lstm2.copyInputs)
+   mytester:assert(not lstm2.copyGradOutputs)
    
    seq:zeroGradParameters()
    re2:zeroGradParameters()

--- a/test/test.lua
+++ b/test/test.lua
@@ -1176,7 +1176,196 @@ function rnntest.SequencerCriterion()
 end
 
 function rnntest.RecurrentAttention()
+   -- so basically, I know that this works because I used it to 
+   -- reproduce a paper's results. So all future RecurrentAttention
+   -- versions should match the behavior of this RATest class.
+   -- Yeah, its ugly, but it's a unit test, so kind of hidden :
+   local RecurrentAttention, parent = torch.class("nn.RATest", "nn.AbstractSequencer")
+
+   function RecurrentAttention:__init(rnn, action, nStep, hiddenSize)
+      parent.__init(self)
+      assert(torch.isTypeOf(rnn, 'nn.AbstractRecurrent'))
+      assert(torch.isTypeOf(action, 'nn.Module'))
+      assert(torch.type(nStep) == 'number')
+      assert(torch.type(hiddenSize) == 'table')
+      assert(torch.type(hiddenSize[1]) == 'number', "Does not support table hidden layers" )
+      
+      self.rnn = rnn
+      self.rnn.copyInputs = true
+      self.action = action -- samples an x,y actions for each example
+      self.hiddenSize = hiddenSize
+      self.nStep = nStep
+      
+      self.modules = {self.rnn, self.action}
+      self.sharedClones = {self.action:sharedClone()} -- action clones
+      
+      self.output = {} -- rnn output
+      self.actions = {} -- action output
+      
+      self.forwardActions = false
+      
+      self.gradHidden = {}
+   end
+
+   function RecurrentAttention:updateOutput(input)
+      self.rnn:forget()
+      local nDim = input:dim()
+      
+      for step=1,self.nStep do
+         -- we maintain a copy of action (with shared params) for each time-step
+         local action = self:getStepModule(step)
+         
+         if step == 1 then
+            -- sample an initial starting actions by forwarding zeros through the action
+            self._initInput = self._initInput or input.new()
+            self._initInput:resize(input:size(1),table.unpack(self.hiddenSize)):zero()
+            self.actions[1] = action:updateOutput(self._initInput)
+         else
+            -- sample actions from previous hidden activation (rnn output)
+            self.actions[step] = action:updateOutput(self.output[step-1])
+         end
+         
+         -- rnn handles the recurrence internally
+         local output = self.rnn:updateOutput{input, self.actions[step]}
+         self.output[step] = self.forwardActions and {output, self.actions[step]} or output
+      end
+      
+      return self.output
+   end
+
+   function RecurrentAttention:updateGradInput(input, gradOutput)
+      assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+      assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
+      assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
+       
+      -- backward through the action
+      for step=self.nStep,1,-1 do
+         local action = self:getStepModule(step)
+         
+         local gradOutput_, gradAction_ = gradOutput[step], action.output:clone():zero()
+         if self.forwardActions then
+            gradOutput_, gradAction_ = unpack(gradOutput[step])
+         end
+         
+         if step == self.nStep then
+            self.gradHidden[step] = nn.rnn.recursiveCopy(self.gradHidden[step], gradOutput_)
+         else
+            -- gradHidden = gradOutput + gradAction
+            nn.rnn.recursiveAdd(self.gradHidden[step], gradOutput_)
+         end
+         
+         if step == 1 then
+            -- backward through initial starting actions
+            action:updateGradInput(self._initInput, gradAction_ or action.output)
+         else
+            -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
+            local gradAction = action:updateGradInput(self.output[step-1], gradAction_)
+            self.gradHidden[step-1] = nn.rnn.recursiveCopy(self.gradHidden[step-1], gradAction)
+         end
+      end
+      
+      -- backward through the rnn layer
+      for step=1,self.nStep do
+         self.rnn.step = step + 1
+         self.rnn:updateGradInput(input, self.gradHidden[step])
+      end
+      -- back-propagate through time (BPTT)
+      self.rnn:updateGradInputThroughTime()
+      
+      for step=self.nStep,1,-1 do
+         local gradInput = self.rnn.gradInputs[step][1]
+         if step == self.nStep then
+            self.gradInput:resizeAs(gradInput):copy(gradInput)
+         else
+            self.gradInput:add(gradInput)
+         end
+      end
+
+      return self.gradInput
+   end
+
+   function RecurrentAttention:accGradParameters(input, gradOutput, scale)
+      assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+      assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
+      assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
+       
+      -- backward through the action layers
+      for step=self.nStep,1,-1 do
+         local action = self:getStepModule(step)
+         local gradAction_ = self.forwardActions and gradOutput[step][2] or action.output:clone():zero()
+               
+         if step == 1 then
+            -- backward through initial starting actions
+            action:accGradParameters(self._initInput, gradAction_, scale)
+         else
+            -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
+            action:accGradParameters(self.output[step-1], gradAction_, scale)
+         end
+      end
+      
+      -- backward through the rnn layer
+      for step=1,self.nStep do
+         self.rnn.step = step + 1
+         self.rnn:accGradParameters(input, self.gradHidden[step], scale)
+      end
+      -- back-propagate through time (BPTT)
+      self.rnn:accGradParametersThroughTime()
+   end
+
+   function RecurrentAttention:accUpdateGradParameters(input, gradOutput, lr)
+      assert(self.rnn.step - 1 == self.nStep, "inconsistent rnn steps")
+      assert(torch.type(gradOutput) == 'table', "expecting gradOutput table")
+      assert(#gradOutput == self.nStep, "gradOutput should have nStep elements")
+       
+      -- backward through the action layers
+      for step=self.nStep,1,-1 do
+         local action = self:getStepModule(step)
+         local gradAction_ = self.forwardActions and gradOutput[step][2] or action.output:clone():zero()
+         
+         if step == 1 then
+            -- backward through initial starting actions
+            action:accUpdateGradParameters(self._initInput, gradAction_, lr)
+         else
+            -- Note : gradOutput is ignored by REINFORCE modules so we give action.output as a dummy variable
+            action:accUpdateGradParameters(self.output[step-1], gradAction_, lr)
+         end
+      end
+      
+      -- backward through the rnn layer
+      for step=1,self.nStep do
+         self.rnn.step = step + 1
+         self.rnn:accUpdateGradParameters(input, self.gradHidden[step], lr)
+      end
+      -- back-propagate through time (BPTT)
+      self.rnn:accUpdateGradParametersThroughTime()
+   end
+
+   function RecurrentAttention:type(type)
+      self._input = nil
+      self._actions = nil
+      self._crop = nil
+      self._pad = nil
+      self._byte = nil
+      return parent.type(self, type)
+   end
+
+   function RecurrentAttention:__tostring__()
+      local tab = '  '
+      local line = '\n'
+      local ext = '  |    '
+      local extlast = '       '
+      local last = '   ... -> '
+      local str = torch.type(self)
+      str = str .. ' {'
+      str = str .. line .. tab .. 'action : ' .. tostring(self.action):gsub(line, line .. tab .. ext)
+      str = str .. line .. tab .. 'rnn     : ' .. tostring(self.rnn):gsub(line, line .. tab .. ext)
+      str = str .. line .. '}'
+      return str
+   end
+
+
    if not pcall(function() require "image" end) then return end -- needs the image package
+   
    local opt = {
       glimpseDepth = 3,
       glimpseHiddenSize = 20,
@@ -1204,6 +1393,7 @@ function rnntest.RecurrentAttention()
    glimpseSensor:add(nn.ReLU())
 
    local glimpse = nn.Sequential()
+   --glimpse:add(nn.PrintSize("preglimpse"))
    glimpse:add(nn.ConcatTable():add(locationSensor):add(glimpseSensor))
    glimpse:add(nn.JoinTable(1,1))
    glimpse:add(nn.Linear(opt.glimpseHiddenSize+opt.locatorHiddenSize, opt.imageHiddenSize))
@@ -1222,24 +1412,83 @@ function rnntest.RecurrentAttention()
    local locator = nn.Sequential()
    locator:add(nn.Linear(opt.hiddenSize, 2))
    locator:add(nn.HardTanh())
-   locator:add(nn.ReinforceNormal(2*opt.locatorStd)) -- uses REINFORCE learning rule
-   locator:add(nn.HardTanh())
    
    -- model is a reinforcement learning agent
-   local rva = nn.RecurrentAttention(rnn, locator, opt.rho, {opt.hiddenSize})
+   local rva2 = nn.RATest(rnn:clone(), locator:clone(), opt.rho, {opt.hiddenSize})
+   local rva = nn.RecurrentAttention(rnn:clone(), locator:clone(), opt.rho, {opt.hiddenSize})
    
    local input = torch.randn(opt.batchSize,1,opt.inputSize,opt.inputSize)
    local gradOutput = {}
    for step=1,opt.rho do
       table.insert(gradOutput, torch.randn(opt.batchSize, opt.hiddenSize))
    end
-   local reward = torch.Tensor(opt.batchSize):random(0,1)
-   for i=1,100 do
-      -- we dont test anything explicitly, we just make sure it doesn't fail
-      input:uniform(-0.5,0.5)
-      rva:forward(input)
-      rva:reinforce(reward)
-      rva:backward(input, gradOutput)
+   
+   -- now we compare to the nn.RATest class (which, we know, works)
+   rva:zeroGradParameters()
+   rva2:zeroGradParameters()
+   
+   local output = rva:forward(input)
+   local output2 = rva2:forward(input)
+   
+   mytester:assert(#output == #output2, "RecurrentAttention #output err")
+   for i=1,#output do
+      mytester:assertTensorEq(output[i], output2[i], 0.0000001, "RecurrentAttention output err "..i)
+   end
+   
+   local gradInput = rva:backward(input, gradOutput)
+   local gradInput2 = rva2:backward(input, gradOutput)
+   
+   mytester:assertTensorEq(gradInput, gradInput2, 0.0000001, "RecurrentAttention gradInput err")
+   
+   rva:updateParameters(1)
+   rva2:updateParameters(1)
+   
+   local params, gradParams = rva:parameters()
+   local params2, gradParams2 = rva2:parameters()
+   
+   for i=1,#params do
+      mytester:assertTensorEq(params[i], params2[i], 0.0000001, "RecurrentAttention, param err "..i)
+      mytester:assertTensorEq(gradParams[i], gradParams2[i], 0.0000001, "RecurrentAttention, gradParam err "..i)
+   end
+   
+   -- test with explicit recursor
+   
+   -- model is a reinforcement learning agent
+   local rva2 = nn.RATest(rnn:clone(), locator:clone(), opt.rho, {opt.hiddenSize})
+   local rva = nn.RecurrentAttention(nn.Recursor(rnn:clone()), locator:clone(), opt.rho, {opt.hiddenSize})
+   
+   local input = torch.randn(opt.batchSize,1,opt.inputSize,opt.inputSize)
+   local gradOutput = {}
+   for step=1,opt.rho do
+      table.insert(gradOutput, torch.randn(opt.batchSize, opt.hiddenSize))
+   end
+   
+   -- now we compare to the nn.RATest class (which, we know, works)
+   rva:zeroGradParameters()
+   rva2:zeroGradParameters()
+   
+   local output = rva:forward(input)
+   local output2 = rva2:forward(input)
+   
+   mytester:assert(#output == #output2, "RecurrentAttention(Recursor) #output err")
+   for i=1,#output do
+      mytester:assertTensorEq(output[i], output2[i], 0.0000001, "RecurrentAttention(Recursor) output err "..i)
+   end
+   
+   local gradInput = rva:backward(input, gradOutput)
+   local gradInput2 = rva2:backward(input, gradOutput)
+   
+   mytester:assertTensorEq(gradInput, gradInput2, 0.0000001, "RecurrentAttention(Recursor) gradInput err")
+   
+   rva:updateParameters(1)
+   rva2:updateParameters(1)
+   
+   local params, gradParams = rva:parameters()
+   local params2, gradParams2 = rva2:parameters()
+   
+   for i=1,#params do
+      mytester:assertTensorEq(params[i], params2[i], 0.0000001, "RecurrentAttention(Recursor), param err "..i)
+      mytester:assertTensorEq(gradParams[i], gradParams2[i], 0.0000001, "RecurrentAttention(Recursor), gradParam err "..i)
    end
 end
    


### PR DESCRIPTION
The Recusor module will allow its decorated module to conform to the AbstractRecurrent interface, thus making it easier to wrap complex graphs in AbstractSequencer instances. 

We need to support the following use cases (task completed when implemented + unit tested) :
 * [x] Recursor(Recurrent)
 * [x] Recusor(LSTM)
 * [x] Recursor(Recursor)
 * [x] Sequencer(Recursor)
 * [x] Repeater(Recursor)
 * [x] RecurrentAttention(Recursor)
 * [x] test eval and train for rmva
 * [x] test recurrent-language-model

Documentation changes :
 * [x] Sequencer
 * [x] Recurrent
 * [x] AbstractRecurrent
 * [x] AbstractSequencer

This PR should be backwards compatible. The main idea to make this work, is to make the AbstractSequencer:backward() call its wrapped AbstractRecurrent instance (like Recursor, Recurrent, LSTM) in reverse order of the forward calls. This way the AbstractRecurrent instance can backpropagate online (generate a gradInput every time-step, in reverse order of forward calls).