### PR TITLE
Support for masking (variable length input)

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -38,6 +38,10 @@ function AbstractRecurrent:getStepModule(step)
    return recurrentModule
 end
 
+function AbstractRecurrent:maskZero()
+   self.recurrentModule = nn.MaskZero(self.recurrentModule)
+end
+
 function AbstractRecurrent:updateGradInput(input, gradOutput)      
    if self.onlineBackward then
       -- updateGradInput will be called in reverse order of time

--- a/MaskZero.lua
+++ b/MaskZero.lua
@@ -16,9 +16,9 @@
 local MaskZero, parent = torch.class("nn.MaskZero", "nn.Decorator")
 
 function MaskZero:updateOutput(input)
-	self.output = self.module:updateOutput(input)
-
-	-- recurrent module input is always the first one
+   self.output = self.module:updateOutput(input)
+   
+   -- recurrent module input is always the first one
    local rmi = input[1]
    -- build mask once
    local vectorDim = rmi:dim() -- works for batch and non batch

--- a/MaskZero.lua
+++ b/MaskZero.lua
@@ -1,0 +1,52 @@
+------------------------------------------------------------------------
+--[[ MaskZero ]]--
+-- Decorator that zeroes the output state of the encapsulated module
+-- for inputs which are zero vectors
+
+-- Emcapsulated module must have the signature of one of the 
+-- AbstractRecurrent's recurrentModule implementation :
+-- LSTM: output, cell = unpack(recurrentModule:updateOutput{input, prevOutput, prevCell})
+-- Recurrent: output = recurrentModule:updateOutput{input, self.output}
+
+-- Zero vectors (i.e. padding) must be at the beginning of the sequence
+-- because this decorator will otherwise reset the recurrentModule
+-- in the middle or after the sequence
+-- TODO add assertion in case padding in uncountered after non padding ?
+------------------------------------------------------------------------
+local MaskZero, parent = torch.class("nn.MaskZero", "nn.Decorator")
+
+function MaskZero:updateOutput(input)
+	self.output = self.module:updateOutput(input)
+
+	-- recurrent module input is always the first one
+   local rmi = input[1]
+   -- build mask once
+   local vectorDim = rmi:dim() -- works for batch and non batch
+   self._zeroMask = torch.norm(rmi, 2, vectorDim):eq(0)
+   -- building mask with code bellow is slower
+   -- self._zeroMask = torch.eq(({torch.min(rmi, vectorDim)})[1], ({torch.max(rmi, vectorDim)})[1])
+
+   -- build mask and use for output (and cell)
+   if torch.type(self.output) == 'table' then
+   	-- LSTM
+   	self._zeroMask = self._zeroMask:expandAs(self.output[1])
+   	-- output
+   	self.output[1]:maskedFill(self._zeroMask, 0)
+   	-- cell: i think zeroing the cell is also mandatory
+   	self.output[2]:maskedFill(self._zeroMask, 0)
+   else
+   	-- Recurrent
+   	self._zeroMask = self._zeroMask:expandAs(self.output)
+   	-- output only
+   	self.output:maskedFill(self._zeroMask, 0)
+   end
+   return self.output
+end
+
+function MaskZero:updateGradInput(input, gradOutput)
+   self.gradInput = self.module:updateGradInput(input, gradOutput)
+   for i=1, #self.gradInput do 
+   	self.gradInput[i]:maskedFill(self._zeroMask, 0)
+   end
+   return self.gradInput
+end

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ to obtain copies of the internal `recurrentModule`. These copies share
 `parameters` and `gradParameters` but each have their own `output`, `gradInput` 
 and any other intermediate states. 
 
+### maskZero() ###
+Decorates the implementing recurrent module with MaskZero. Recurrent module output
+will be zeroed for input data which is a zero vector. This makes possible to pad
+sequences with different lengths in the same batch with zero vectors.
+Warning: padding must come before any real data in the input sequence (padding
+after the real data is not supported and will yield unpredictable results without failing).
+
 ### [output] updateOutput(input) ###
 Forward propagates the input for the current step. The outputs or intermediate 
 states of the previous steps are used recurrently. This is transparent to the 

--- a/init.lua
+++ b/init.lua
@@ -18,6 +18,7 @@ torch.include('rnn', 'ZeroGrad.lua')
 torch.include('rnn', 'LinearNoBias.lua')
 
 -- recurrent modules
+torch.include('rnn', 'MaskZero.lua')
 torch.include('rnn', 'AbstractRecurrent.lua')
 torch.include('rnn', 'Recurrent.lua')
 torch.include('rnn', 'LSTM.lua')

--- a/test/test.lua
+++ b/test/test.lua
@@ -2103,6 +2103,106 @@ function rnntest.Recursor()
    
 end
 
+-- mock Recurrent and LSTM recurrentModules for UT
+-- must be stateless
+-- forwarding zeros must not return zeros -> use Sigmoid()
+function recurrentModule()
+   local recurrent = nn.Sequential()
+   local parallel = nn.ParallelTable()
+   parallel:add(nn.Sigmoid()); parallel:add(nn.Identity())
+   recurrent = nn.Sequential()
+   recurrent:add(parallel)
+   recurrent:add(nn.SelectTable(1))
+   return recurrent
+end
+
+function lstmModule()
+   local recurrent = nn.Sequential()
+   local parallel = nn.ParallelTable()
+   parallel:add(nn.Sigmoid()); parallel:add(nn.Identity()); parallel:add(nn.Identity())
+   recurrent = nn.Sequential()
+   recurrent:add(parallel)
+   recurrent:add(nn.NarrowTable(1, 2))
+   return recurrent
+end
+
+function firstElement(a)
+   return torch.type(a) == 'table' and a[1] or a
+end
+
+function rnntest.MaskZero()
+   local recurrents = {['recurrent'] = recurrentModule(), ['lstm'] = lstmModule()}
+   -- Note we use lstmModule input signature and firstElement to prevent duplicate code
+   for name, recurrent in pairs(recurrents) do
+      -- test encapsulated module first
+      -- non batch
+      local i = torch.rand(10)
+      local e = nn.Sigmoid():forward(i)
+      local o = firstElement(recurrent:forward({i, torch.zeros(10), torch.zeros(10)}))
+      mytester:assertlt(torch.norm(o - e), precision, 'mock ' .. name .. ' failed for non batch')
+      -- batch
+      local i = torch.rand(5, 10)
+      local e = nn.Sigmoid():forward(i)
+      local o = firstElement(recurrent:forward({i, torch.zeros(5, 10), torch.zeros(5, 10)}))
+      mytester:assertlt(torch.norm(o - e), precision, 'mock ' .. name .. ' module failed for batch')
+    
+      -- test mask zero module now
+      local module = nn.MaskZero(recurrent)
+      -- non batch forward
+      local i = torch.rand(10)
+      local e = firstElement(recurrent:forward({i, torch.rand(10), torch.rand(10)}))
+      local o = firstElement(module:forward({i, torch.rand(10), torch.rand(10)}))
+      mytester:assertgt(torch.norm(i - o), precision, 'error on non batch forward for ' .. name)
+      mytester:assertlt(torch.norm(e - o), precision, 'error on non batch forward for ' .. name)
+      local i = torch.zeros(10)
+      local o = firstElement(module:forward({i, torch.rand(10), torch.rand(10)}))
+      mytester:assertlt(torch.norm(i - o), precision, 'error on non batch forward for ' .. name)
+      -- batch forward
+      local i = torch.rand(5, 10)
+      local e = firstElement(recurrent:forward({i, torch.rand(5, 10), torch.rand(5, 10)}))
+      local o = firstElement(module:forward({i, torch.rand(5, 10), torch.rand(5, 10)}))
+      mytester:assertgt(torch.norm(i - o), precision, 'error on batch forward for ' .. name)
+      mytester:assertlt(torch.norm(e - o), precision, 'error on batch forward for ' .. name)
+      local i = torch.zeros(5, 10)
+      local o = firstElement(module:forward({i, torch.rand(5, 10), torch.rand(5, 10)}))
+      mytester:assertlt(torch.norm(i - o), precision, 'error on batch forward for ' .. name)
+      local i = torch.Tensor({{0, 0, 0}, {1, 2, 5}})
+      -- clone r because it will be update by module:forward call
+      local r = firstElement(recurrent:forward({i, torch.rand(2, 3), torch.rand(2, 3)})):clone()
+      local o = firstElement(module:forward({i, torch.rand(2, 3), torch.rand(2, 3)}))
+      mytester:assertgt(torch.norm(r - o), precision, 'error on batch forward for ' .. name)
+      r[1]:zero()
+      mytester:assertlt(torch.norm(r - o), precision, 'error on batch forward for ' .. name)
+
+      -- check gradients
+      local jac = nn.Jacobian
+      local sjac = nn.SparseJacobian
+      -- Note: testJacobian doesn't support table inputs or outputs
+      -- Use a SplitTable and SelectTable to adapt module
+      local module = nn.Sequential()
+      module:add(nn.SplitTable(1))
+      module:add(nn.MaskZero(recurrent))
+      if name == 'lstm' then module:add(nn.SelectTable(1)) end
+
+      local input = torch.rand(name == 'lstm' and 3 or 2, 10)
+      local err = jac.testJacobian(module, input)
+      mytester:assertlt(err, precision, 'error on state for ' .. name)
+      -- IO
+      local ferr,berr = jac.testIO(module,input)
+      mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err for ' .. name)
+      mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err for ' .. name)
+      -- batch
+      -- rebuild module to avoid correlated tests
+      local module = nn.Sequential()
+      module:add(nn.SplitTable(1))
+      module:add(nn.MaskZero(recurrent))
+      if name == 'lstm' then module:add(nn.SelectTable(1)) end
+
+      local input = torch.rand(name == 'lstm' and 3 or 2, 5, 10)
+      local err = jac.testJacobian(module,input)
+      mytester:assertlt(err, precision, 'batch error on state for ' .. name)
+   end
+end
 
 function rnn.test(tests)
    mytester = torch.Tester()


### PR DESCRIPTION
This is a PR for https://github.com/Element-Research/rnn/issues/45
(Sorry for the name change, @sensout is an organization).

I've tested it on both CPU and GPU (CUDA only).
See my remarks about mandatory forward padding.
You might find a more generic and elegant way to cope with the different `recurrentModule` signatures.

About performance, I've seen a 10% speed decrease with zero mask enabled.
Checking all inputs to find even a few paddings is costly (there might be better options than computing the norm). It would be nice if performance penalty was proportional to the number of paddings only (but I don't see how).

Note: I'm currently using it with a LookupTable where the weight is forced to zero for padding and I guess I could also make a PR for a LookupTableZeroMask (or whatever name you prefer) inheriting `nn.Decorator` to support any LookupTable implementation.

Cheers