### PR TITLE
Add LookupTableMaskZero to support padding for different length sequences

### DIFF
--- a/LookupTableMaskZero.lua
+++ b/LookupTableMaskZero.lua
@@ -1,0 +1,16 @@
+local LookupTableMaskZero, parent = torch.class('nn.LookupTableMaskZero', 'nn.LookupTable')
+
+function LookupTableMaskZero:__init(nIndex, nOutput)
+  parent.__init(self, nIndex + 1, nOutput)
+end
+
+function LookupTableMaskZero:updateOutput(input)
+	self.weight[1]:zero()
+	return parent.updateOutput(self, torch.add(input, 1))
+end
+
+-- No need to override accGradParameters because input is cached
+-- by nn.LookupTable implementation and gradOuput is already as expected
+--[[function LookupTable:accGradParameters(input, gradOutput, scale)
+	parent.accGradParameters(self, torch.add(input, 1), gradOutput, scale)
+end--]]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Modules that `forward` entire sequences through a decorated `AbstractRecurrent` 
 
 Miscellaneous modules :
  * [MaskZero](#rnn.MaskZero) : zeroes the `output` rows of the decorated module for commensurate `input` rows which are tensors of zeros.
+ * [LookupTableMaskZero](#rnn.LookupTableMaskZero) : extends `nn.LookupTable` to support zero indexes for padding. Zero indexes are forwarded as tensors of zeros.
 
 Criterions used for handling sequential inputs and targets :
  * [SequencerCriterion](#rnn.SequencerCriterion) : sequentially applies the same criterion to a sequence of inputs and targets;
@@ -905,6 +906,18 @@ in the first Tensor of the `input`. In the case of an `input` table,
 the first Tensor is the first one encountered when doing a depth-first search.
 
 This decorator makes it possible to pad sequences with different lengths in the same batch with zero vectors.
+
+<a name='rnn.LookupTableMaskZero'></a>
+## LookupTableMaskZero ##
+This module extends `nn.LookupTable` to support zero indexes. Zero indexes are forwarded as zero tensors.
+
+```lua
+lt = nn.LookupTableMaskZero(nIndex, nOutput)
+```
+
+The `output` Tensor will have each row zeroed when the commensurate row of the `input` is a zero index. 
+
+This lookup table makes it possible to pad sequences with different lengths in the same batch with zero vectors.
 
 <a name='rnn.SequencerCriterion'></a>
 ## SequencerCriterion ##

--- a/init.lua
+++ b/init.lua
@@ -18,6 +18,7 @@ torch.include('rnn', 'ZeroGrad.lua')
 torch.include('rnn', 'LinearNoBias.lua')
 
 -- recurrent modules
+torch.include('rnn', 'LookupTableMaskZero.lua')
 torch.include('rnn', 'MaskZero.lua')
 torch.include('rnn', 'AbstractRecurrent.lua')
 torch.include('rnn', 'Recurrent.lua')


### PR DESCRIPTION
Following https://github.com/Element-Research/rnn/pull/46# ,
this is a lookup table extending `nn.LookupTable` adding support for padding sequences with different length.
I agree this could be in `dpnn` (because it could have some use elsewhere) but I think it is better to keep it close to `nn.MaskZero`.
To make it transparent for non padded dataset, I chose to fix the padding index to 0 (which is not used in this case).

Feel free to change anything you would like.

Cheers