### PR TITLE
FastLSTM nngraph version

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -190,10 +190,10 @@ function AbstractRecurrent:includingSharedClones(f)
          table.insert(self.modules, module)
       end
    end
-   local r = f()
+   local r = {f()}
    self.modules = modules
    self.sharedClones = sharedClones
-   return r
+   return unpack(r)
 end
 
 function AbstractRecurrent:type(type)

--- a/FastLSTM.lua
+++ b/FastLSTM.lua
@@ -1,5 +1,8 @@
 local FastLSTM, parent = torch.class("nn.FastLSTM", "nn.LSTM")
 
+-- set this to true to have it use nngraph instead of nn
+FastLSTM.usenngraph = false
+
 function FastLSTM:__init(inputSize, outputSize, rho)
    parent.__init(self, inputSize, outputSize, rho, false)
 end
@@ -12,7 +15,8 @@ function FastLSTM:buildModel()
    self.i2g = nn.Linear(self.inputSize, 4*self.outputSize)
    self.o2g = nn.LinearNoBias(self.outputSize, 4*self.outputSize)
    
-   if nngraph then
+   if self.usenngraph then
+      require 'nngraph'
       return self:nngraphModel()
    end
 

--- a/FastLSTM.lua
+++ b/FastLSTM.lua
@@ -11,6 +11,10 @@ function FastLSTM:buildModel()
    -- Calculate all four gates in one go : input, hidden, forget, output
    self.i2g = nn.Linear(self.inputSize, 4*self.outputSize)
    self.o2g = nn.LinearNoBias(self.outputSize, 4*self.outputSize)
+   
+   if nngraph then
+      return self:nngraphModel()
+   end
 
    local para = nn.ParallelTable():add(self.i2g):add(self.o2g)
    local gates = nn.Sequential()
@@ -69,6 +73,42 @@ function FastLSTM:buildModel()
    seq:add(concat)
    
    return seq
+end
+
+function FastLSTM:nngraphModel()
+   assert(nngraph, "Missing nngraph package")
+   
+   local inputs = {}
+   table.insert(inputs, nn.Identity()()) -- x
+   table.insert(inputs, nn.Identity()()) -- prev_h[L]
+   table.insert(inputs, nn.Identity()()) -- prev_c[L]
+   
+   local x, prev_h, prev_c = unpack(inputs)
+   
+   -- evaluate the input sums at once for efficiency
+   local i2h = self.i2g(x):annotate{name='i2h'}
+   local h2h = self.o2g(prev_h):annotate{name='h2h'}
+   local all_input_sums = nn.CAddTable()({i2h, h2h})
+
+   local reshaped = nn.Reshape(4, self.outputSize)(all_input_sums)
+   -- input, hidden, forget, output
+   local n1, n2, n3, n4 = nn.SplitTable(2)(reshaped):split(4)
+   local in_gate = nn.Sigmoid()(n1)
+   local in_transform = nn.Tanh()(n2)
+   local forget_gate = nn.Sigmoid()(n3)
+   local out_gate = nn.Sigmoid()(n4)
+   
+   -- perform the LSTM update
+   local next_c           = nn.CAddTable()({
+     nn.CMulTable()({forget_gate, prev_c}),
+     nn.CMulTable()({in_gate,     in_transform})
+   })
+   -- gated cells form the output
+   local next_h = nn.CMulTable()({out_gate, nn.Tanh()(next_c)})
+
+   local outputs = {next_h, next_c}
+   
+   return nn.gModule(inputs, outputs)
 end
 
 function FastLSTM:buildGate()

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -212,6 +212,7 @@ function LSTM:backwardThroughTime(timeStep, rho)
          local inputTable = {self.inputs[step], output, cell}
          local gradCell = (step == self.step-1) and (self.userNextGradCell or self.zeroTensor) or self.gradCells[step]
          local gradInputTable = recurrentModule:backward(inputTable, {gradOutput, gradCell}, scale)
+         local gradInput
          gradInput, self.gradPrevOutput, gradCell = unpack(gradInputTable)
          self.gradCells[step-1] = gradCell
          table.insert(self.gradInputs, 1, gradInput)

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -14,7 +14,7 @@ local LSTM, parent = torch.class('nn.LSTM', 'nn.AbstractRecurrent')
 function LSTM:__init(inputSize, outputSize, rho, cell2gate)
    parent.__init(self, rho or 9999)
    self.inputSize = inputSize
-   self.outputSize = outputSize   
+   self.outputSize = outputSize or inputSize
    -- build the model
    self.cell2gate = (cell2gate == nil) and true or cell2gate
    self.recurrentModule = self:buildModel()

--- a/Module.lua
+++ b/Module.lua
@@ -35,12 +35,25 @@ end
 
 -- notifies all AbstractRecurrent instances not wrapped by an AbstractSequencer
 -- that the backward calls will be handled online (in reverse order of forward time).
-function Module:backwardOnline(online)
+function Module:backwardOnline(online, root)
+   root = (root == nil) or root
    if self.modules then
       for i, module in ipairs(self.modules) do
-         module:backwardOnline(online)
+         module:backwardOnline(online, false)
       end
    end
+   
+   -- backwardOnline doesn't require copyInputs, copyGradOutputs
+   if root then
+      for i,modula in ipairs(self:listModules()) do
+         if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
+            modula.copyInputs = false
+            modula.copyGradOutputs = false
+         end
+      end
+      self.copyInputs = false
+      self.copyGradOutputs = false
+   end   
 end
 
 -- set the maximum number of backpropagation through time (BPTT) time-steps

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -10,11 +10,11 @@ function Recursor:__init(module, rho)
    parent.__init(self, rho or 9999999)
 
    self.recurrentModule = module
-   self.recurrentModule:backwardOnline()
-   self.onlineBackward = true
    
    self.module = module
    self.modules = {module}
+   
+   self:backwardOnline()
 end
 
 function Recursor:updateOutput(input)
@@ -26,13 +26,6 @@ function Recursor:updateOutput(input)
       output = recurrentModule:updateOutput(input)
    else
       output = self.recurrentModule:updateOutput(input)
-   end
-   
-   if self.train ~= false then
-      local input_ = self.inputs[self.step]
-      self.inputs[self.step] = self.copyInputs 
-         and nn.rnn.recursiveCopy(input_, input) 
-         or nn.rnn.recursiveSet(input_, input)     
    end
    
    self.outputs[self.step] = output

--- a/Sequencer.lua
+++ b/Sequencer.lua
@@ -23,13 +23,6 @@ function Sequencer:__init(module)
    self.module:backwardOnline()
    self.modules = {self.module}
    
-   for i,modula in ipairs(self.module:listModules()) do
-      if torch.isTypeOf(modula, "nn.AbstractRecurrent") then
-         modula.copyInputs = false
-         modula.copyGradOutputs = false
-      end
-   end
-   
    self.output = {}
    
    -- table of buffers used for evaluation

--- a/recursiveUtils.lua
+++ b/recursiveUtils.lua
@@ -22,7 +22,7 @@ function rnn.recursiveSet(t1,t2)
          t1[key], t2[key] = rnn.recursiveSet(t1[key], t2[key])
       end
    elseif torch.isTensor(t2) then
-      t1 = t1 or t2.new()
+      t1 = torch.isTensor(t1) and t1 or t2.new()
       t1:set(t2)
    else
       error("expecting nested tensors or tables. Got "..


### PR DESCRIPTION
The PR includes a version of FastLSTM that uses an nngraph module internally. I thought this would be even faster, but it's actually not obvious which implementation is faster. The benchmark included in the unit test seems to tell the tale that nn is a little faster most of the time on my end. Maybe its different of you?

Also includes some unit test benchmarks for our LSTM implementation vs char-rnn's (work in progress).

Depends on https://github.com/nicholas-leonard/dpnn/pull/32