### PR TITLE
remove possible stale input gradients for RepeaterCriterion

### DIFF
--- a/RepeaterCriterion.lua
+++ b/RepeaterCriterion.lua
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 --[[ RepeaterCriterion ]]--
--- Applies a criterion to each of the inputs in a Table using the 
--- same target (the target is repeated). 
+-- Applies a criterion to each of the inputs in a Table using the
+-- same target (the target is repeated).
 -- Useful for nn.Repeater and nn.Sequencer.
 ------------------------------------------------------------------------
 assert(not nn.RepeaterCriterion, "update nnx package : luarocks install nnx")
@@ -24,6 +24,9 @@ end
 function RepeaterCriterion:backward(inputTable, target)
    for i,input in ipairs(inputTable) do
       self.gradInput[i] = nn.rnn.recursiveCopy(self.gradInput[i], self.criterion:backward(input, target))
+   end
+   for i = #inputTable+1, #self.gradInput do
+      self.gradInput[i] = nil
    end
    return self.gradInput
 end


### PR DESCRIPTION
Hi Nick,

I believe I have found a bug regarding how `RepeaterCriterion` computes its input gradients. Namely, it doesn't remove possible stale gradients from previous `backward` calls by iterating through the entirety of its `gradInput` table. This means that if you call `backward` with a longer sequence, any subsequent `backward` calls with shorter sequences will crash because the input gradient table will contain stale vectors from the first `backward` call. I've made a simple fix for this for your review.

Thanks,
Victor