### PR TITLE
show input & output size in __tostring__

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -200,3 +200,11 @@ end
 function AbstractRecurrent:backwardUpdateThroughTime(learningRate)
    error"DEPRECATED Jan 8, 2016"
 end
+
+function AbstractRecurrent:__tostring__()
+   if self.inputSize and self.outputSize then
+       return self.__typename .. string.format("(%d -> %d)", self.inputSize, self.outputSize)
+   else
+       return parent.__tostring__(self)
+   end
+end


### PR DESCRIPTION
When printed, the input size and output size of a recurrent unit are shown, useful when designing a new network.

To illustrate, 
```
nn.Sequencer @ nn.LSTM
nn.Sequencer @ nn.FastLSTM
nn.Sequencer @ nn.GRU
```
becomes
```
nn.Sequencer @ nn.LSTM(30 -> 20)
nn.Sequencer @ nn.FastLSTM(30 -> 20)
nn.Sequencer @ nn.GRU(30 -> 20)
```