### PR TITLE
fix #170

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -17,6 +17,7 @@ function AbstractRecurrent:__init(rho)
    
    -- stores internal states of Modules at different time-steps
    self.sharedClones = {}
+   self.trim = false
    
    self:reset()
 end
@@ -40,7 +41,8 @@ end
 
 function AbstractRecurrent:trimZero(nInputDim)
    self.recurrentModule = nn.TrimZero(self.recurrentModule, nInputDim, true)
-   self.sharedClones = {self.recurrentModule}
+   self.sharedClones = {self.recurrentModule:stepClone()}
+   self.trim = true
    return self
 end
 
@@ -112,7 +114,7 @@ function AbstractRecurrent:forget()
       -- Since its used for evaluation, it should be used for training. 
       local nClone, maxIdx = 0, 1
       for k,v in pairs(self.sharedClones) do -- to prevent odd bugs
-         if torch.pointer(v) == torch.pointer(self.recurrentModule) then
+         if self.trim or torch.pointer(v) == torch.pointer(self.recurrentModule) then
             self.rmInSharedClones = true
             maxIdx = math.max(k, maxIdx)
          end

--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -39,6 +39,9 @@ function AbstractRecurrent:maskZero(nInputDim)
 end
 
 function AbstractRecurrent:trimZero(nInputDim)
+   if torch.typename(self)=='nn.GRU' and self.p ~= 0 then
+      assert(self.mono, "TrimZero for BGRU needs `mono` option.")
+   end
    self.recurrentModule = nn.TrimZero(self.recurrentModule, nInputDim, true)
    self.sharedClones = {self.recurrentModule}
    return self

--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -17,7 +17,6 @@ function AbstractRecurrent:__init(rho)
    
    -- stores internal states of Modules at different time-steps
    self.sharedClones = {}
-   self.trim = false
    
    self:reset()
 end
@@ -41,8 +40,7 @@ end
 
 function AbstractRecurrent:trimZero(nInputDim)
    self.recurrentModule = nn.TrimZero(self.recurrentModule, nInputDim, true)
-   self.sharedClones = {self.recurrentModule:stepClone()}
-   self.trim = true
+   self.sharedClones = {self.recurrentModule}
    return self
 end
 
@@ -114,7 +112,7 @@ function AbstractRecurrent:forget()
       -- Since its used for evaluation, it should be used for training. 
       local nClone, maxIdx = 0, 1
       for k,v in pairs(self.sharedClones) do -- to prevent odd bugs
-         if self.trim or torch.pointer(v) == torch.pointer(self.recurrentModule) then
+         if torch.pointer(v) == torch.pointer(self.recurrentModule) then
             self.rmInSharedClones = true
             maxIdx = math.max(k, maxIdx)
          end

--- a/Dropout.lua
+++ b/Dropout.lua
@@ -9,12 +9,13 @@
 ------------------------------------------------------------------------
 local Dropout, Parent = nn.Dropout, nn.Module
 
-function Dropout:__init(p,v1,inplace,lazy)
+function Dropout:__init(p,v1,inplace,lazy,mono)
    Parent.__init(self)
    self.p = p or 0.5
    self.train = true
    self.inplace = inplace
    self.lazy = lazy or false
+   self.mono = mono or false  -- used by trimZero, single sample for a batch
    self.flag = true  -- used by lazy noise
    -- version 2 scales output during training instead of evaluation
    self.v2 = not v1
@@ -33,12 +34,17 @@ function Dropout:updateOutput(input)
    if self.p > 0 then
       if self.train then
          if not self.lazy or self.flag then
-            self.noise:resizeAs(input)
+            local noiseSize = input:size()
+            if self.mono then noiseSize[1] = 1 end
+            self.noise:resize(noiseSize)
             self.noise:bernoulli(1-self.p)
             if self.v2 then
                self.noise:div(1-self.p)
             end
             self.flag = false
+         end
+         if self.mono and self.noise:size(1) ~= input:size(1) then
+            self.noise = self.noise:expandAs(input)
          end
          self.output:cmul(self.noise)
       elseif not self.v2 then

--- a/GRU.lua
+++ b/GRU.lua
@@ -16,13 +16,13 @@
 assert(not nn.GRU, "update nnx package : luarocks install nnx")
 local GRU, parent = torch.class('nn.GRU', 'nn.AbstractRecurrent')
 
-function GRU:__init(inputSize, outputSize, rho, p, mono)
+function GRU:__init(inputSize, outputSize, rho, p)
    parent.__init(self, rho or 9999)
    self.p = p or 0
    if p and p ~= 0 then
       assert(nn.Dropout(p,false,false,true).lazy, 'only work with Lazy Dropout!')
    end
-   self.mono = mono or false  -- used by trimZero
+   self.mono = p ~= 0
    self.inputSize = inputSize
    self.outputSize = outputSize   
    -- build the model

--- a/test/test.lua
+++ b/test/test.lua
@@ -3828,18 +3828,16 @@ function rnntest.TrimZero()
    end
 
    -- check to have the same loss
-   rnn_size = 8
-   vocabSize = 7
-   word_embedding_size = 10
-
-   x = torch.Tensor{{{1,2,3},{0,4,5},{0,0,7}},
-                    {{1,2,3},{2,4,5},{0,0,7}},
-                    {{1,2,3},{2,4,5},{3,0,7}}}
-   t = torch.ceil(torch.rand(x:size(2)))
-
-   rnns = {'FastLSTM','GRU'}
-   methods = {'maskZero', 'trimZero'}
-   loss = torch.Tensor(#rnns, #methods, 3)
+   local rnn_size = 8
+   local vocabSize = 7
+   local word_embedding_size = 10
+   local x = torch.Tensor{{{1,2,3},{0,4,5},{0,0,7}},
+                          {{1,2,3},{2,4,5},{0,0,7}},
+                          {{1,2,3},{2,4,5},{3,0,7}}}
+   local t = torch.ceil(torch.rand(x:size(2)))
+   local rnns = {'FastLSTM','GRU'}
+   local methods = {'maskZero', 'trimZero'}
+   local loss = torch.Tensor(#rnns, #methods, 3)
 
    for ir,arch in pairs(rnns) do
       local rnn = nn[arch](word_embedding_size, rnn_size)
@@ -3850,7 +3848,7 @@ function rnntest.TrimZero()
                   :add(nn.SelectTable(-1))
                   :add(nn.Linear(rnn_size, 10))
       model:getParameters():uniform(-0.1, 0.1)
-      criterion = nn.CrossEntropyCriterion()
+      local criterion = nn.CrossEntropyCriterion()
       local models = {}
       for j=1,#methods do
          table.insert(models, model:clone())
@@ -3858,20 +3856,20 @@ function rnntest.TrimZero()
       for im,method in pairs(methods) do
          -- print('-- '..arch..' with '..method)
          model = models[im]
-         rnn = model:get(3).module
+         local rnn = model:get(3).module
          rnn[method](rnn, 1)
-         sys.tic()
+         -- sys.tic()
          for i=1,loss:size(3) do
             model:zeroGradParameters()
-            y = model:forward(x[i])
+            local y = model:forward(x[i])
             loss[ir][im][i] = criterion:forward(y,t)
             -- print('loss:', loss[ir][im][i])
-            dy = criterion:backward(y,t)
+            local dy = criterion:backward(y,t)
             model:backward(x[i], dy)
-            w,dw = model:parameters()
+            local w,dw = model:parameters()
             model:updateParameters(.5)
          end
-         elapse = sys.toc()
+         -- elapse = sys.toc()
          -- print('elapse time:', elapse)   
       end
    end
@@ -4245,18 +4243,16 @@ end
 function rnntest.issue170()
    torch.manualSeed(123)
 
-   rnn_size = 8
-   vocabSize = 7
-   word_embedding_size = 10
-   rnn_dropout = .00000001  -- dropout ignores manualSeed()
-   mono = true
-
-   x = torch.Tensor{{1,2,3},{0,4,5},{0,0,7}}
-   t = torch.ceil(torch.rand(x:size(2)))
-
-   rnns = {'GRU'}
-   methods = {'maskZero', 'trimZero'}
-   loss = torch.Tensor(#rnns, #methods,1)
+   local rnn_size = 8
+   local vocabSize = 7
+   local word_embedding_size = 10
+   local rnn_dropout = .00000001  -- dropout ignores manualSeed()
+   local mono = true
+   local x = torch.Tensor{{1,2,3},{0,4,5},{0,0,7}}
+   local t = torch.ceil(torch.rand(x:size(2)))
+   local rnns = {'GRU'}
+   local methods = {'maskZero', 'trimZero'}
+   local loss = torch.Tensor(#rnns, #methods,1)
 
    for ir,arch in pairs(rnns) do
       local rnn = nn[arch](word_embedding_size, rnn_size, nil, rnn_dropout)
@@ -4267,22 +4263,22 @@ function rnntest.issue170()
                   :add(nn.SelectTable(-1))
                   :add(nn.Linear(rnn_size, 10))
       model:getParameters():uniform(-0.1, 0.1)
-      criterion = nn.CrossEntropyCriterion()
+      local criterion = nn.CrossEntropyCriterion()
       local models = {}
       for j=1,#methods do
          table.insert(models, model:clone())
       end
       for im,method in pairs(methods) do
          model = models[im]
-         rnn = model:get(3).module
+         local rnn = model:get(3).module
          rnn[method](rnn, 1)
          for i=1,loss:size(3) do
             model:zeroGradParameters()
-            y = model:forward(x)
+            local y = model:forward(x)
             loss[ir][im][i] = criterion:forward(y,t)
-            dy = criterion:backward(y,t)
+            local dy = criterion:backward(y,t)
             model:backward(x, dy)
-            w,dw = model:parameters()
+            local w,dw = model:parameters()
             model:updateParameters(.5)
          end
       end

--- a/test/test.lua
+++ b/test/test.lua
@@ -4259,7 +4259,7 @@ function rnntest.issue170()
    loss = torch.Tensor(#rnns, #methods,1)
 
    for ir,arch in pairs(rnns) do
-      local rnn = nn[arch](word_embedding_size, rnn_size, nil, rnn_dropout, mono)
+      local rnn = nn[arch](word_embedding_size, rnn_size, nil, rnn_dropout)
       local model = nn.Sequential()
                   :add(nn.LookupTableMaskZero(vocabSize, word_embedding_size))
                   :add(nn.SplitTable(2))


### PR DESCRIPTION
I discovered there was an interaction between TrimZero and BGRU after polishing the trimZero code.

Lazy Dropout couldn't handle variable input (batch) size after trimming, I added a `mono` option to sample once for a batch for expanding across the batch.

It fixed #170.