### PR TITLE
Fixed encoder-decoder-coupling.lua bug

### DIFF
--- a/examples/encoder-decoder-coupling.lua
+++ b/examples/encoder-decoder-coupling.lua
@@ -11,8 +11,8 @@ version = 1.2 -- refactored numerical gradient test into unit tests. Added train
 local opt = {}
 opt.learningRate = 0.1
 opt.hiddenSize = 6
-opt.vocabSize = 5
-opt.seqLen = 3 -- length of the encoded sequence
+opt.vocabSize = 6
+opt.seqLen = 2 -- length of the encoded sequence
 opt.niter = 1000
 
 --[[ Forward coupling: Copy encoder cell and output to decoder LSTM ]]--


### PR DESCRIPTION
Previously failed to run due to error. 

```
/Users/surya/torch/install/bin/luajit: /Users/surya/torch/install/share/lua/5.1/nn/THNN.lua:109: Assertion `cur_target >= 0 && cur_target < n_classes' failed.  at /tmp/luarocks_nn-scm-1-5291/nn/lib/THNN/generic/ClassNLLCriterion.c:50
```