### PR TITLE
remove return of undefined variable

### DIFF
--- a/Recurrent.lua
+++ b/Recurrent.lua
@@ -127,8 +127,6 @@ function Recurrent:_accGradParameters(input, gradOutput, scale)
    else
       error"non-positive time-step"
    end
-   
-   return gradInput
 end
 
 function Recurrent:recycle()


### PR DESCRIPTION
I guess this is a typo since `_accGradParameters()` should not return anything.
