### PR TITLE
Correct reference from `rnn` to `module`

### DIFF
--- a/Repeater.lua
+++ b/Repeater.lua
@@ -11,7 +11,7 @@ function Repeater:__init(module, rho)
    parent.__init(self)
    assert(torch.type(rho) == 'number', "expecting number value for arg 2")
    self.rho = rho
-   self.module = (not torch.isTypeOf(rnn, 'nn.AbstractRecurrent')) and nn.Recursor(module) or module
+   self.module = (not torch.isTypeOf(module, 'nn.AbstractRecurrent')) and nn.Recursor(module) or module
    
    self.module:maxBPTTstep(rho) -- hijack rho (max number of time-steps for backprop)
    


### PR DESCRIPTION
`Repeater:__init` was incorrectly referring to a global variable `rnn` rather than the input argument `module`, causing unnecessary wrapping of input module by `nn.Recursor` in many cases (i.e. when global name `rnn` doesn't exist) and a failure to wrap the module with `nn.Recursor`, if there already happens to be a global name `rnn` referring to an instance of `AbstractRecurrent`.