### PR TITLE
Inform LookupTable that 1 is padding

### DIFF
--- a/LookupTableMaskZero.lua
+++ b/LookupTableMaskZero.lua
@@ -1,7 +1,7 @@
 local LookupTableMaskZero, parent = torch.class('nn.LookupTableMaskZero', 'nn.LookupTable')
 
 function LookupTableMaskZero:__init(nIndex, nOutput)
-  parent.__init(self, nIndex + 1, nOutput)
+  parent.__init(self, nIndex + 1, nOutput, 1)
 end
 
 function LookupTableMaskZero:updateOutput(input)


### PR DESCRIPTION
It looks like CPU (and GPU, to a probably lesser degree) [nn.LUT](https://github.com/torch/nn/blob/ee1646f2036d1177b7621b1bf86f8a5c247504e6/LookupTable.lua#L11) can [save some computation](https://github.com/torch/nn/blob/master/lib/THNN/generic/LookupTable.c#L87) by not accumulating parameter gradients for a given index.