### PR TITLE
change init.lua to match test directory

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,8 +18,8 @@ torch.include('rnn', 'Module.lua')
 torch.include('rnn', 'Dropout.lua')
 
 -- for testing:
-torch.include('rnn', 'test.lua')
-torch.include('rnn', 'bigtest.lua')
+torch.include('rnn', 'test/test.lua')
+torch.include('rnn', 'test/bigtest.lua')
 
 -- support modules
 torch.include('rnn', 'ZeroGrad.lua')


### PR DESCRIPTION
I imagine that at some point `test.lua` and `bigtest.lua` got moved inside the `test/` directory. Assuming that they should still be part of the library, this should import them properly.