### PR TITLE
Add ExpandAs module

### DIFF
--- a/ExpandAs.lua
+++ b/ExpandAs.lua
@@ -1,0 +1,36 @@
+ExpandAs, parent = torch.class('nn.ExpandAs', 'nn.Module')
+-- expands the second input to match the first
+
+function ExpandAs:__init()
+  parent.__init(self)
+  self.output = {}
+  self.gradInput = {}
+
+  self.sum1 = torch.Tensor()
+  self.sum2 = torch.Tensor()
+end
+
+function ExpandAs:updateOutput(input)
+  self.output[1] = input[1]
+  self.output[2] = input[2]:expandAs(input[1])
+  return self.output
+end
+
+function ExpandAs:updateGradInput(input, gradOutput)
+  local b, db = input[2], gradOutput[2]
+  local s1, s2 = self.sum1, self.sum2
+  local sumSrc, sumDst = db, s1
+
+  for i=1,b:dim() do
+    if b:size(i) ~= db:size(i) then
+      sumDst:sum(sumSrc, i)
+      sumSrc = sumSrc == s1 and s2 or s1
+      sumDst = sumDst == s1 and s2 or s1
+    end
+  end
+
+  self.gradInput[1] = gradOutput[1]
+  self.gradInput[2] = sumSrc
+
+  return self.gradInput
+end


### PR DESCRIPTION
As suggested by the title, this module takes as input `{a, b}` and expands `b` to have the same shape as `a` (assuming that the singleton dimensions match).

Although I'm not sure if this module is complex enough to warrant inclusion in this repo, I've found that it's useful when applying a mask along the seqlen dimension of (Seq|cudnn) RNNs when the sequence length varies.

If this proposal interests anyone, I'll complete the PR with tests and docs.
