### PR TITLE
Actually support passing tables of LongStorage as output size

### DIFF
--- a/Recurrence.lua
+++ b/Recurrence.lua
@@ -34,7 +34,7 @@ end
 -- This zero Tensor is forwarded as output(t=0).
 function Recurrence:recursiveResizeZero(tensor, size, batchSize)
    local isTable = torch.type(size) == 'table'
-   if isTable and torch.type(size[1]) == 'table' then
+   if isTable and torch.type(size[1]) ~= 'number' then
       tensor = (torch.type(tensor) == 'table') and tensor or {}
       for k,v in ipairs(size) do
          tensor[k] = self:recursiveResizeZero(tensor[k], v, batchSize)


### PR DESCRIPTION
According to the docs for `Recurrence`,

> it needs to know the outputSize, which is either a number or torch.LongStorage, or table thereof

This is currently untrue as there is no case for it in `recursiveResizeZero`! This PR remedies this by treating a table of `LongStorage`s as a table of tables.

Note that the initial check in `__init` guarantees that the only other input type to `recursiveResizeZero` is `number`, so checking that `type(size) ~= 'number'` is valid.