### PR TITLE
Get hidden state

### DIFF
--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -225,6 +225,15 @@ function AbstractRecurrent:maxBPTTstep(rho)
    self.rho = rho
 end
 
+-- get hidden state: h[t]
+function AbstractRecurrent:getHiddenState(step, input)
+   error"Not Implemented"
+end
+
+function AbstractRecurrent:setHiddenState(step, hiddenState)
+   error"Not Implemented"
+end
+
 -- backwards compatibility
 AbstractRecurrent.recursiveResizeAs = rnn.recursiveResizeAs
 AbstractRecurrent.recursiveSet = rnn.recursiveSet

--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -13,6 +13,7 @@ function AbstractRecurrent:__init(rho)
    self.outputs = {}
    self.gradInputs = {}
    self._gradOutputs = {}
+   self.gradOutputs = {}
 
    self.step = 1
 
@@ -100,7 +101,7 @@ end
 function nn.AbstractRecurrent:clearState()
    self:forget()
    -- keep the first two sharedClones
-   nn.utils.clear(self, '_input', '_gradOutput', '_gradOutputs', 'gradPrevOutput', 'cell', 'cells', 'gradCells', 'outputs', 'gradInputs')
+   nn.utils.clear(self, '_input', '_gradOutput', '_gradOutputs', 'gradPrevOutput', 'cell', 'cells', 'gradCells', 'outputs', 'gradInputs', 'gradOutputs')
    for i, clone in ipairs(self.sharedClones) do
       clone:clearState()
    end
@@ -120,13 +121,17 @@ function AbstractRecurrent:forget()
       self.gradInputs = {}
       self.sharedClones = _.compact(self.sharedClones)
       self._gradOutputs = _.compact(self._gradOutputs)
+      self.gradOutputs = {}
+      if self.cells then
+         self.cells = {}
+         self.gradCells = {}
+      end
    end
 
    -- forget the past inputs; restart from first step
    self.step = 1
 
-
-  if not self.rmInSharedClones then
+   if not self.rmInSharedClones then
       -- Asserts that issue 129 is solved. In forget as it is often called.
       -- Asserts that self.recurrentModule is part of the sharedClones.
       -- Since its used for evaluation, it should be used for training.
@@ -225,11 +230,12 @@ function AbstractRecurrent:maxBPTTstep(rho)
    self.rho = rho
 end
 
--- get hidden state: h[t]
+-- get stored hidden state: h[t] where h[t] = f(x[t], h[t-1])
 function AbstractRecurrent:getHiddenState(step, input)
    error"Not Implemented"
 end
 
+-- set stored hidden state
 function AbstractRecurrent:setHiddenState(step, hiddenState)
    error"Not Implemented"
 end

--- a/AbstractRecurrent.lua
+++ b/AbstractRecurrent.lua
@@ -240,6 +240,16 @@ function AbstractRecurrent:setHiddenState(step, hiddenState)
    error"Not Implemented"
 end
 
+-- get stored grad hidden state: grad(h[t])
+function AbstractRecurrent:getGradHiddenState(step, input)
+   error"Not Implemented"
+end
+
+-- set stored grad hidden state
+function AbstractRecurrent:setGradHiddenState(step, hiddenState)
+   error"Not Implemented"
+end
+
 -- backwards compatibility
 AbstractRecurrent.recursiveResizeAs = rnn.recursiveResizeAs
 AbstractRecurrent.recursiveSet = rnn.recursiveSet

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -136,22 +136,29 @@ function LSTM:buildModel()
    return model
 end
 
-------------------------- forward backward -----------------------------
-function LSTM:updateOutput(input)
+function LSTM:getHiddenState(step, input)
    local prevOutput, prevCell
-   if self.step == 1 then
+   if step == 0 then
       prevOutput = self.userPrevOutput or self.zeroTensor
       prevCell = self.userPrevCell or self.zeroTensor
-      if input:dim() == 2 then
-         self.zeroTensor:resize(input:size(1), self.outputSize):zero()
-      else
-         self.zeroTensor:resize(self.outputSize):zero()
+      if input then
+         if input:dim() == 2 then
+            self.zeroTensor:resize(input:size(1), self.outputSize):zero()
+         else
+            self.zeroTensor:resize(self.outputSize):zero()
+         end
       end
    else
       -- previous output and cell of this module
-      prevOutput = self.outputs[self.step-1]
-      prevCell = self.cells[self.step-1]
+      prevOutput = self.outputs[step]
+      prevCell = self.cells[step]
    end
+   return {prevOutput, prevCell}
+end
+
+------------------------- forward backward -----------------------------
+function LSTM:updateOutput(input)
+   local prevOutput, prevCell = unpack(self:getHiddenState(self.step-1, input))
 
    -- output(t), cell(t) = lstm{input(t), output(t-1), cell(t-1)}
    local output, cell

--- a/LSTM.lua
+++ b/LSTM.lua
@@ -227,11 +227,9 @@ function LSTM:_updateGradInput(input, gradOutput)
    local _gradOutput, gradCell = gradHiddenState[1], gradHiddenState[2]
    assert(_gradOutput and gradCell)
 
-   if _gradOutput then
-      self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], _gradOutput)
-      nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
-      gradOutput = self._gradOutputs[step]
-   end
+   self._gradOutputs[step] = nn.rnn.recursiveCopy(self._gradOutputs[step], _gradOutput)
+   nn.rnn.recursiveAdd(self._gradOutputs[step], gradOutput)
+   gradOutput = self._gradOutputs[step]
 
    local inputTable = self:getHiddenState(step-1)
    table.insert(inputTable, 1, input)

--- a/Module.lua
+++ b/Module.lua
@@ -1,4 +1,4 @@
-local Module = nn.Module 
+local Module = nn.Module
 
 -- You can use this to manually forget past memories in AbstractRecurrent instances
 function Module:forget()
@@ -44,6 +44,25 @@ function Module:maxBPTTstep(rho)
    if self.modules then
       for i, module in ipairs(self.modules) do
          module:maxBPTTstep(rho)
+      end
+   end
+end
+
+function Module:getHiddenState(step)
+   if self.modules then
+      local hiddenState = {}
+      for i, module in ipairs(self.modules) do
+         hiddenState[i] = module:getHiddenState(step)
+      end
+      return hiddenState
+   end
+end
+
+function Module:setHiddenState(step, hiddenState)
+   if self.modules then
+      tc.checktab(hiddenState, 2)
+      for i, module in ipairs(self.modules) do
+         module:setHiddenState(step, hiddenState[i])
       end
    end
 end

--- a/Module.lua
+++ b/Module.lua
@@ -60,9 +60,28 @@ end
 
 function Module:setHiddenState(step, hiddenState)
    if self.modules then
-      tc.checktab(hiddenState, 2)
+      assert(torch.type(hiddenState) == 'table')
       for i, module in ipairs(self.modules) do
          module:setHiddenState(step, hiddenState[i])
+      end
+   end
+end
+
+function Module:getGradHiddenState(step)
+   if self.modules then
+      local gradHiddenState = {}
+      for i, module in ipairs(self.modules) do
+         gradHiddenState[i] = module:getGradHiddenState(step)
+      end
+      return gradHiddenState
+   end
+end
+
+function Module:setGradHiddenState(step, gradHiddenState)
+   if self.modules then
+      assert(torch.type(gradHiddenState) == 'table')
+      for i, module in ipairs(self.modules) do
+         module:setGradHiddenState(step, gradHiddenState[i])
       end
    end
 end

--- a/Recurrence.lua
+++ b/Recurrence.lua
@@ -171,10 +171,10 @@ function Recurrence:_updateGradInput(input, gradOutput)
 
    local gradInputTable = recurrentModule:updateGradInput({input, self:getHiddenState(step-1)[1]}, gradOutput)
 
-   local gradInput = table.remove(gradInputTable, 1)
-   self:setGradHiddenState(step-1, gradInputTable)
+   local _ = require 'moses'
+   self:setGradHiddenState(step-1, _.slice(gradInputTable, 2, #gradInputTable))
 
-   return gradInput
+   return gradInputTable[1]
 end
 
 function Recurrence:_accGradParameters(input, gradOutput, scale)

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -1,8 +1,8 @@
 ------------------------------------------------------------------------
 --[[ Recursor ]]--
 -- Decorates module to be used within an AbstractSequencer.
--- It does this by making the decorated module conform to the 
--- AbstractRecurrent interface (which is inherited by LSTM/Recurrent) 
+-- It does this by making the decorated module conform to the
+-- AbstractRecurrent interface (which is inherited by LSTM/Recurrent)
 ------------------------------------------------------------------------
 local Recursor, parent = torch.class('nn.Recursor', 'nn.AbstractRecurrent')
 
@@ -10,7 +10,7 @@ function Recursor:__init(module, rho)
    parent.__init(self, rho or 9999999)
 
    self.recurrentModule = module
-   
+
    self.module = module
    self.modules = {module}
    self.sharedClones[1] = self.recurrentModule
@@ -26,7 +26,7 @@ function Recursor:updateOutput(input)
    else
       output = self.recurrentModule:updateOutput(input)
    end
-   
+
    self.outputs[self.step] = output
    self.output = output
    self.step = self.step + 1
@@ -39,18 +39,18 @@ function Recursor:_updateGradInput(input, gradOutput)
    assert(self.step > 1, "expecting at least one updateOutput")
    local step = self.updateGradInputStep - 1
    assert(step >= 1)
-   
+
    local recurrentModule = self:getStepModule(step)
    recurrentModule:setOutputStep(step)
    local gradInput = recurrentModule:updateGradInput(input, gradOutput)
-   
+
    return gradInput
 end
 
 function Recursor:_accGradParameters(input, gradOutput, scale)
    local step = self.accGradParametersStep - 1
    assert(step >= 1)
-   
+
    local recurrentModule = self:getStepModule(step)
    recurrentModule:setOutputStep(step)
    recurrentModule:accGradParameters(input, gradOutput, scale)
@@ -82,5 +82,10 @@ function Recursor:maxBPTTstep(rho)
    self.rho = rho
    nn.Module.maxBPTTstep(self, rho)
 end
+
+Recursor.getHiddenState = nn.Container.getHiddenState
+Recursor.setHiddenState = nn.Container.setHiddenState
+Recursor.getGradHiddenState = nn.Container.getGradHiddenState
+Recursor.setGradHiddenState = nn.Container.setGradHiddenState
 
 Recursor.__tostring__ = nn.Decorator.__tostring__

--- a/Recursor.lua
+++ b/Recursor.lua
@@ -83,9 +83,20 @@ function Recursor:maxBPTTstep(rho)
    nn.Module.maxBPTTstep(self, rho)
 end
 
-Recursor.getHiddenState = nn.Container.getHiddenState
-Recursor.setHiddenState = nn.Container.setHiddenState
-Recursor.getGradHiddenState = nn.Container.getGradHiddenState
-Recursor.setGradHiddenState = nn.Container.setGradHiddenState
+function Recursor:getHiddenState(...)
+   return self.modules[1]:getHiddenState(...)
+end
+
+function Recursor:setHiddenState(...)
+   return self.modules[1]:setHiddenState(...)
+end
+
+function Recursor:getGradHiddenState(...)
+   return self.modules[1]:getGradHiddenState(...)
+end
+
+function Recursor:setGradHiddenState(...)
+   return self.modules[1]:setGradHiddenState(...)
+end
 
 Recursor.__tostring__ = nn.Decorator.__tostring__

--- a/examples/encoder-decoder-coupling.lua
+++ b/examples/encoder-decoder-coupling.lua
@@ -6,7 +6,7 @@ Example of "coupled" separate encoder and decoder networks, e.g. for sequence-to
 
 require 'rnn'
 
-version = 1.3 -- Added multiple layers and merged with seqLSTM example
+version = 1.4 -- Uses [get,set]GradHiddenState for LSTM
 
 local opt = {}
 opt.learningRate = 0.1
@@ -37,8 +37,7 @@ function backwardConnect(enc, dec)
          enc.lstmLayers[i].userNextGradCell = dec.lstmLayers[i].userGradPrevCell
          enc.lstmLayers[i].gradPrevOutput = dec.lstmLayers[i].userGradPrevOutput
       else
-         enc.lstmLayers[i].userNextGradCell = nn.rnn.recursiveCopy(enc.lstmLayers[i].userNextGradCell, dec.lstmLayers[i].userGradPrevCell)
-         enc.lstmLayers[i].gradPrevOutput = nn.rnn.recursiveCopy(enc.lstmLayers[i].gradPrevOutput, dec.lstmLayers[i].userGradPrevOutput)
+         enc:setGradHiddenState(opt.seqLen, dec:getGradHiddenState(0))
       end
    end
 end
@@ -101,7 +100,7 @@ for i=1,opt.niter do
    local decOut = dec:forward(decInSeq)
    --print(decOut)
    local err = criterion:forward(decOut, decOutSeq)
-   
+
    print(string.format("Iteration %d ; NLL err = %f ", i, err))
 
    -- Backward pass

--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,7 @@ assert(dpnn.version > 1, "Please update dpnn : luarocks install dpnn")
 -- create global rnn table:
 rnn = {}
 rnn.version = 2
+rnn.version = 2.1 -- [get,set][Grad]HiddenState(step)
 
 unpack = unpack or table.unpack
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -6679,7 +6679,7 @@ function rnntest.inplaceBackward()
    end
 end
 
-function rnntest.LSTM_GRU_hiddenState()
+function rnntest.getHiddenState()
    local seqlen, batchsize = 7, 3
    local inputsize, outputsize = 4, 5
    local input = torch.randn(seqlen*2, batchsize, inputsize)
@@ -6757,7 +6757,12 @@ function rnntest.LSTM_GRU_hiddenState()
 
    local lstm = nn.LSTM(inputsize, outputsize)
    testHiddenState(lstm)
-   testHiddenState(nn.GRU(inputsize, outputsize))
+
+   local gru = nn.GRU(inputsize, outputsize)
+   testHiddenState(gru)
+
+   gru:forget()
+   testHiddenState(nn.Recursor(gru), false)
 
    local rm = lstm.recurrentModule:clone()
 


### PR DESCRIPTION
This update adds AbstractRecurrent:[get,set][Grad]HiddenState methods. These methods make it easier to build things like encoder-decoder coupling or, more generally, sequence to sequence RNNS.