### PR TITLE
"maxnormout" -> "maxNorm"

### DIFF
--- a/examples/recurrent-language-model.lua
+++ b/examples/recurrent-language-model.lua
@@ -73,7 +73,7 @@ local lm = nn.Sequential()
 
 -- input layer (i.e. word embedding space)
 local lookup = nn.LookupTable(#trainset.ivocab, opt.inputsize)
-lookup.maxnormout = -1 -- prevent weird maxnormout behaviour
+lookup.maxNorm = -1 -- prevent weird maxnormout behaviour
 lm:add(lookup) -- input is seqlen x batchsize
 if opt.dropout > 0 and not opt.gru then  -- gru has a dropout option
    lm:add(nn.Dropout(opt.dropout))


### PR DESCRIPTION
[nn.LookupTable.lua](https://github.com/torch/nn/blob/master/LookupTable.lua) does not have `maxnormout` field. Correcting to `maxNorm`.