### PR TITLE
Fixed bug in FastLSTM dropout initialization

### DIFF
--- a/FastLSTM.lua
+++ b/FastLSTM.lua
@@ -31,7 +31,7 @@ function FastLSTM:__init(inputSize, outputSize, rho, eps, momentum, affine, p, m
    end
    self.mono = mono or false
 
-   parent.__init(self, inputSize, outputSize, rho)
+   parent.__init(self, inputSize, outputSize, rho, nil, p, mono)
 end
 
 function FastLSTM:buildModel()


### PR DESCRIPTION
In the current version, dropout isn't enabled when creating a FastLSTM instance: the value of `p` or `mono` that we specify is overwritten when creating the parent LSTM instance.

Example of the bug:
We first create a FastLSTM:
`lstm = nn.FastLSTM(2, 3, nil, nil, nil, nil, 0.5, true)`
Now we can check that `lstm.p` is equal to `0`, even though we would expect to get `0.5`. Similarly, `lstm.mono` will be `false` instead of `true`.

This simple edit fixes this behavior.