### PR TITLE
Reset flag in Dropout to prevent bug if the state is cleared

### DIFF
--- a/Dropout.lua
+++ b/Dropout.lua
@@ -83,3 +83,11 @@ end
 function Dropout:__tostring__()
    return string.format('%s(%.1f, %s)', torch.type(self), self.p, self.lazy and 'lazy' or 'busy')
 end
+
+function Dropout:clearState()
+   if self.noise then
+      self.noise:set()
+   end
+   self.flag = true
+   return Parent.clearState(self)
+end


### PR DESCRIPTION
Calling `clearState()` on a lazy Dropout layer doesn't reset the `flag`, which means that the noise isn't generated again once it's called with a new input. This causes a crash as follows:

```
d = nn.Dropout(0.5,false,false,true)
input = torch.randn(2, 3)
d:forward(input)
d:clearState()
d:forward(input)
```

The simple fix is to reset `flag` to `true` when calling `clearState()`.
